### PR TITLE
[MCOMPILER-178] add List parameter compilerArgs

### DIFF
--- a/maven-compiler-plugin/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/maven-compiler-plugin/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -233,10 +233,28 @@ public abstract class AbstractCompilerMojo
      * </pre>
      *
      * @since 2.0.1
+     * @deprecated use {@link #compilerArgs} instead. 
      */
     @Parameter
+    @Deprecated
     protected Map<String, String> compilerArguments;
 
+    /**
+     * <p>
+     * Sets the arguments to be passed to the compiler if {@link #fork} is set to <code>true</code>.
+     * Example:
+     * <pre>
+     * &lt;compilerArgs&gt;
+     *   &lt;arg&gt;-Xmaxerrs=1000&lt;/arg&gt;
+     *   &lt;arg&gt;-Xlint&lt;/arg&gt;
+     * &lt;/compilerArgs&gt;
+     * </pre>
+     *
+     * @since 3.1
+     */
+    @Parameter
+    protected List<String> compilerArgs;
+    
     /**
      * <p>
      * Sets the unformatted single argument string to be passed to the compiler if {@link #fork} is set to <code>true</code>.
@@ -489,7 +507,7 @@ public abstract class AbstractCompilerMojo
 
         String effectiveCompilerArgument = getCompilerArgument();
 
-        if ( ( effectiveCompilerArguments != null ) || ( effectiveCompilerArgument != null ) )
+        if ( ( effectiveCompilerArguments != null ) || ( effectiveCompilerArgument != null ) || ( compilerArgs != null ) )
         {
             LinkedHashMap<String, String> cplrArgsCopy = new LinkedHashMap<String, String>();
             if ( effectiveCompilerArguments != null )
@@ -516,6 +534,13 @@ public abstract class AbstractCompilerMojo
             if ( !StringUtils.isEmpty( effectiveCompilerArgument ) )
             {
                 cplrArgsCopy.put( effectiveCompilerArgument, null );
+            }
+            if ( compilerArgs != null )
+            {
+                for ( String arg : compilerArgs )
+                {
+                    cplrArgsCopy.put( arg, null );
+                }
             }
             compilerConfiguration.setCustomCompilerArguments( cplrArgsCopy );
         }

--- a/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
+++ b/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
@@ -32,6 +32,7 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -205,6 +206,7 @@ public class CompilerMojoTestCase
 
         File testClass = new File( compileMojo.getOutputDirectory(), "compiled.class" );
         assertTrue( testClass.exists() );
+        assertEquals( Arrays.asList( "key1=value1","-Xlint","-my&special:param-with+chars/not>allowed_in_XML_element_names" ), compileMojo.compilerArgs );
     }
 
     public void testOneOutputFileForAllInput2()

--- a/maven-compiler-plugin/src/test/resources/unit/compiler-args-test/plugin-config.xml
+++ b/maven-compiler-plugin/src/test/resources/unit/compiler-args-test/plugin-config.xml
@@ -36,6 +36,11 @@
               <param2>value2</param2>
             </compilerArgument>
           </compilerArguments>
+          <compilerArgs>
+              <arg>key1=value1</arg>
+              <arg>-Xlint</arg>
+              <arg><![CDATA[-my&special:param-with+chars/not>allowed_in_XML_element_names]]></arg>
+          </compilerArgs>
           <compilerArgument>param value</compilerArgument>
         </configuration>
       </plugin>


### PR DESCRIPTION
Add List parameter compilerArgs which only uses
values of configuration XML elements.
Deprecate Map parameter compilerArguments because
1. it adds "-" in front of the key and "=" between key and value
   which is an implicit assumption on argument syntax that
   is generally is not desired
1. ultimately since the XML element name is used as key,
   certain characters not allowed in XML element can't be used
   and there is no way to escape these characters in XML

The new parameter allows to escape unallowed XML
characters
e.g. using <![CDATA[my special weird non-XML valid
argument]]>
since only the text body of the XML element is used as
argument to pass to the compiler.
