### PR TITLE
Updated shade mojo to use another artifactId

### DIFF
--- a/maven-shade-plugin/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/maven-shade-plugin/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -47,6 +47,7 @@ import org.apache.maven.plugins.shade.pom.PomWriter;
 import org.apache.maven.plugins.shade.relocation.Relocator;
 import org.apache.maven.plugins.shade.relocation.SimpleRelocator;
 import org.apache.maven.plugins.shade.resource.ResourceTransformer;
+import org.apache.maven.project.DefaultMavenProjectHelper;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
@@ -526,14 +527,19 @@ public class ShadeMojo
                     renamed = true;
                 }
 
+                MavenProject usedProject = project;
+                if(shadedArtifactId!=null) {
+                	usedProject = new MavenProject(project.getModel());
+                	usedProject.setArtifactId(shadedArtifactId);
+                }
                 if ( shadedArtifactAttached )
                 {
                     getLog().info( "Attaching shaded artifact." );
-                    projectHelper.attachArtifact( project, project.getArtifact().getType(), shadedClassifierName,
+                    projectHelper.attachArtifact( usedProject, usedProject.getArtifact().getType(), shadedClassifierName,
                                                   outputJar );
                     if ( createSourcesJar )
                     {
-                        projectHelper.attachArtifact( project, "jar", shadedClassifierName + "-sources", sourcesJar );
+                    	projectHelper.attachArtifact( usedProject, "jar", shadedClassifierName + "-sources", sourcesJar );
                     }
                 }
                 else if ( !renamed )


### PR DESCRIPTION
This pull request correspond to a mail i sent later on to maven-dev concerning one issue with maven-shade-plugin.
Although there is a `shadedArtifactId` field declared in ShadeMojo, it is absolutely unused.
I used that field to create a new project using that artifactId, instead of standard one.
I didn't wrote a test, as the current testing infrastructure seems strange to use. If a test is mandatory, I would gladly write one, provided someone mentors me on that subject.
