### PR TITLE
[MPMD-168] Add parameter to skip report generation if there are no violations/duplications.

### DIFF
--- a/maven-pmd-plugin/src/it/mpmd-168-empty-report/invoker.properties
+++ b/maven-pmd-plugin/src/it/mpmd-168-empty-report/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean verify site

--- a/maven-pmd-plugin/src/it/mpmd-168-empty-report/pom.xml
+++ b/maven-pmd-plugin/src/it/mpmd-168-empty-report/pom.xml
@@ -22,35 +22,52 @@ under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.apache.maven.its.pmd.mm</groupId>
-    <artifactId>parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
-  </parent>
+  <groupId>org.apache.maven.plugin.pmd.its</groupId>
+  <artifactId>mpmd-168-empty-report</artifactId>
+  <version>1.0-SNAPSHOT</version>
 
-  <artifactId>mod-1</artifactId>
-
-  <name>Module 1</name>
+  <name>MPMD-168 do not skip empty report</name>
   <description>
-    Test proper report generation in a multi-module build.
+    Verify the "skipEmptyReport" parameter.
   </description>
 
-  <properties>
-    <project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
-  </properties>
-
-  <reporting>
+  <build>
     <plugins>
       <plugin>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+              <goal>cpd-check</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
-          <rulesets>
-            <ruleset>src/main/config/pmd/utf-8.xml</ruleset>
-            <ruleset>src/main/config/pmd/latin-1.xml</ruleset>
-          </rulesets>
+          <verbose>true</verbose>
+          <minimumTokens>25</minimumTokens>
+          <sourceEncoding>UTF-8</sourceEncoding>
+          <failOnViolation>false</failOnViolation> <!-- force execution of both goals, will be checked with verify-script -->
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
           <skipEmptyReport>false</skipEmptyReport>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>2.3</version>
       </plugin>
     </plugins>
   </reporting>

--- a/maven-pmd-plugin/src/it/mpmd-168-empty-report/src/main/java/def/Hello.java
+++ b/maven-pmd-plugin/src/it/mpmd-168-empty-report/src/main/java/def/Hello.java
@@ -1,0 +1,28 @@
+package def;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Hello
+{
+    public static void main( String[] args )
+    {
+        System.out.println( args[0] );
+    }
+}

--- a/maven-pmd-plugin/src/it/mpmd-168-empty-report/verify.groovy
+++ b/maven-pmd-plugin/src/it/mpmd-168-empty-report/verify.groovy
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File targetDir = new File( basedir, "target" );
+File siteDir = new File( targetDir, "site" );
+
+File projectReports = new File( siteDir, "project-reports.html" )
+assert projectReports.getText( "UTF-8" ).contains( "pmd.html" )
+assert projectReports.getText( "UTF-8" ).contains( "cpd.html" )
+
+File pmdReportInSite = new File( siteDir, "pmd.html" )
+assert pmdReportInSite.exists()
+
+File pmdXmlInTarget = new File( targetDir, "pmd.xml" )
+assert pmdXmlInTarget.exists()
+
+File cpdReportInSite = new File( siteDir, "cpd.html" )
+assert cpdReportInSite.exists()
+
+File cpdXmlInTarget = new File( targetDir, "cpd.xml" )
+assert cpdXmlInTarget.exists()

--- a/maven-pmd-plugin/src/it/mpmd-168/invoker.properties
+++ b/maven-pmd-plugin/src/it/mpmd-168/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean verify site

--- a/maven-pmd-plugin/src/it/mpmd-168/pom.xml
+++ b/maven-pmd-plugin/src/it/mpmd-168/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.plugin.pmd.its</groupId>
-  <artifactId>mpmd-168-empty-report</artifactId>
+  <artifactId>mpmd-168-empty-report-skipped</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <name>MPMD-168 skip empty report</name>
@@ -45,7 +45,6 @@ under the License.
           </execution>
         </executions>
         <configuration>
-          <skipEmptyReport>true</skipEmptyReport>
           <verbose>true</verbose>
           <minimumTokens>25</minimumTokens>
           <sourceEncoding>UTF-8</sourceEncoding>
@@ -62,7 +61,7 @@ under the License.
         <artifactId>maven-pmd-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-            <skipEmptyReport>true</skipEmptyReport>
+<!--           <skipEmptyReport>true</skipEmptyReport> it's by default true -->
         </configuration>
       </plugin>
       <plugin>

--- a/maven-pmd-plugin/src/it/mpmd-168/pom.xml
+++ b/maven-pmd-plugin/src/it/mpmd-168/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugin.pmd.its</groupId>
+  <artifactId>mpmd-168-empty-report</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>MPMD-168 skip empty report</name>
+  <description>
+    Verify the "skipEmptyReport" parameter.
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+              <goal>cpd-check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skipEmptyReport>true</skipEmptyReport>
+          <verbose>true</verbose>
+          <minimumTokens>25</minimumTokens>
+          <sourceEncoding>UTF-8</sourceEncoding>
+          <failOnViolation>false</failOnViolation> <!-- force execution of both goals, will be checked with verify-script -->
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+            <skipEmptyReport>true</skipEmptyReport>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>2.3</version>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/maven-pmd-plugin/src/it/mpmd-168/src/main/java/def/Hello.java
+++ b/maven-pmd-plugin/src/it/mpmd-168/src/main/java/def/Hello.java
@@ -1,0 +1,28 @@
+package def;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Hello
+{
+    public static void main( String[] args )
+    {
+        System.out.println( args[0] );
+    }
+}

--- a/maven-pmd-plugin/src/it/mpmd-168/verify.groovy
+++ b/maven-pmd-plugin/src/it/mpmd-168/verify.groovy
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File targetDir = new File( basedir, "target" );
+File siteDir = new File( targetDir, "site" );
+
+File projectReports = new File( siteDir, "project-reports.html" )
+assert !projectReports.getText( "UTF-8" ).contains( "pmd.html" )
+assert !projectReports.getText( "UTF-8" ).contains( "cpd.html" )
+
+File pmdReportInSite = new File( siteDir, "pmd.html" )
+assert !pmdReportInSite.exists()
+
+File pmdXmlInTarget = new File( targetDir, "pmd.xml" )
+assert pmdXmlInTarget.exists()
+
+File cpdReportInSite = new File( siteDir, "cpd.html" )
+assert !cpdReportInSite.exists()
+
+File cpdXmlInTarget = new File( targetDir, "cpd.xml" )
+assert cpdXmlInTarget.exists()

--- a/maven-pmd-plugin/src/it/multi-module/mod-1/src/main/config/pmd/latin-1.xml
+++ b/maven-pmd-plugin/src/it/multi-module/mod-1/src/main/config/pmd/latin-1.xml
@@ -7,6 +7,6 @@
   <description>
     This ruleset is encoded with ISO-8859-1 to check proper encoding handling.
   </description>
-  <rule ref="rulesets/basic.xml/UnnecessaryReturn" message="LATIN-1-CHARS: ÄÖÜäöüß¼½¾¤"/>
+  <rule ref="rulesets/java/basic.xml/UnnecessaryReturn" message="LATIN-1-CHARS: ÄÖÜäöüß¼½¾¤"/>
   <!-- note: ¼½¾¤ = 0xBC 0xBD 0xBE 0xA4 don't exist any more in Latin 15, replaced by OE oe Y" and euro -->
 </ruleset>

--- a/maven-pmd-plugin/src/it/multi-module/mod-1/src/main/config/pmd/utf-8.xml
+++ b/maven-pmd-plugin/src/it/multi-module/mod-1/src/main/config/pmd/utf-8.xml
@@ -7,5 +7,5 @@
   <description>
     This ruleset is encoded with UTF-8 to check proper encoding handling.
   </description>
-  <rule ref="rulesets/basic.xml/EmptyStatementNotInLoop" message="UTF-8-CHARS: ÄÖÜäöüß¼½¾¤"/>
+  <rule ref="rulesets/java/basic.xml/EmptyStatementNotInLoop" message="UTF-8-CHARS: ÄÖÜäöüß¼½¾¤"/>
 </ruleset>

--- a/maven-pmd-plugin/src/it/multi-module/mod-2/pom.xml
+++ b/maven-pmd-plugin/src/it/multi-module/mod-2/pom.xml
@@ -43,8 +43,9 @@ under the License.
         <configuration>
           <rulesets>
             <!-- NOTE: Clashes with classpath resource, check resolution -->
-            <ruleset>rulesets/basic.xml</ruleset>
+            <ruleset>rulesets/java/basic.xml</ruleset>
           </rulesets>
+          <skipEmptyReport>false</skipEmptyReport>
         </configuration>
       </plugin>
     </plugins>

--- a/maven-pmd-plugin/src/it/multi-module/mod-2/rulesets/java/basic.xml
+++ b/maven-pmd-plugin/src/it/multi-module/mod-2/rulesets/java/basic.xml
@@ -7,5 +7,5 @@
   <description>
     The relative path of this ruleset matches the built-in ruleset "basic".
   </description>
-  <rule ref="rulesets/basic.xml/EmptyStatementNotInLoop" message="TEST: LOCAL-FILE-RULESET"/>
+  <rule ref="rulesets/java/basic.xml/EmptyStatementNotInLoop" message="TEST: LOCAL-FILE-RULESET"/>
 </ruleset>

--- a/maven-pmd-plugin/src/it/multi-module/mod-3/pom.xml
+++ b/maven-pmd-plugin/src/it/multi-module/mod-3/pom.xml
@@ -46,6 +46,7 @@ under the License.
             <ruleset>src/main/config/pmd/rel.xml</ruleset>
             <ruleset>${basedir}/src/main/config/pmd/abs.xml</ruleset>
           </rulesets>
+          <skipEmptyReport>false</skipEmptyReport>
         </configuration>
       </plugin>
     </plugins>

--- a/maven-pmd-plugin/src/it/multi-module/mod-3/src/main/config/pmd/abs.xml
+++ b/maven-pmd-plugin/src/it/multi-module/mod-3/src/main/config/pmd/abs.xml
@@ -7,5 +7,5 @@
   <description>
     This ruleset is specified via an absolute filesystem path.
   </description>
-  <rule ref="rulesets/basic.xml/UnnecessaryReturn" message="TEST: ABSOLUTE-PATH"/>
+  <rule ref="rulesets/java/basic.xml/UnnecessaryReturn" message="TEST: ABSOLUTE-PATH"/>
 </ruleset>

--- a/maven-pmd-plugin/src/it/multi-module/mod-3/src/main/config/pmd/rel.xml
+++ b/maven-pmd-plugin/src/it/multi-module/mod-3/src/main/config/pmd/rel.xml
@@ -7,5 +7,5 @@
   <description>
     This ruleset is specified via a relative filesystem path.
   </description>
-  <rule ref="rulesets/basic.xml/EmptyStatementNotInLoop" message="TEST: RELATIVE-PATH"/>
+  <rule ref="rulesets/java/basic.xml/EmptyStatementNotInLoop" message="TEST: RELATIVE-PATH"/>
 </ruleset>

--- a/maven-pmd-plugin/src/it/multi-module/mod-4/pom.xml
+++ b/maven-pmd-plugin/src/it/multi-module/mod-4/pom.xml
@@ -42,6 +42,7 @@ under the License.
         <version>@project.version@</version>
         <configuration>
           <format>none</format>
+          <skipEmptyReport>false</skipEmptyReport>
         </configuration>
       </plugin>
     </plugins>

--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/AbstractPmdReport.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/AbstractPmdReport.java
@@ -195,6 +195,18 @@ public abstract class AbstractPmdReport
     protected boolean includeXmlInSite;
 
     /**
+     * Skip the PMD/CPD report generation if there are no violations or duplications found.
+     * Defaults to <code>false</code> to preserve legacy behaviour pre 3.1.
+     *
+     * @since 3.1
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean skipEmptyReport;
+
+    /** The files that are being analyzed. */
+    protected Map<File, PmdFileInfo> filesToProcess;
+
+    /**
      * {@inheritDoc}
      */
     protected MavenProject getProject()
@@ -396,6 +408,10 @@ public abstract class AbstractPmdReport
     {
         return "html".equals( format );
     }
+    protected boolean isXml()
+    {
+        return "xml".equals( format );
+    }
 
     /**
      * {@inheritDoc}
@@ -414,13 +430,13 @@ public abstract class AbstractPmdReport
 
         // if format is XML, we need to output it even if the file list is empty
         // so the "check" goals can check for failures
-        if ( "xml".equals( format ) )
+        if ( isXml() )
         {
             return true;
         }
         try
         {
-            Map<File, PmdFileInfo> filesToProcess = getFilesToProcess();
+            filesToProcess = getFilesToProcess();
             if ( filesToProcess.isEmpty() )
             {
                 return false;

--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/AbstractPmdReport.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/AbstractPmdReport.java
@@ -196,11 +196,11 @@ public abstract class AbstractPmdReport
 
     /**
      * Skip the PMD/CPD report generation if there are no violations or duplications found.
-     * Defaults to <code>false</code> to preserve legacy behaviour pre 3.1.
+     * Defaults to <code>true</code>.
      *
      * @since 3.1
      */
-    @Parameter( defaultValue = "false" )
+    @Parameter( defaultValue = "true" )
     protected boolean skipEmptyReport;
 
     /** The files that are being analyzed. */

--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/CpdReport.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/CpdReport.java
@@ -165,6 +165,10 @@ public class CpdReport
                 if ( skipEmptyReport )
                 {
                     result = cpd.getMatches().hasNext();
+                    if ( result )
+                    {
+                        getLog().debug("Skipping Report as skipEmptyReport is true and there are no CPD issues.");
+                    }
                 }
             }
             catch ( MavenReportException e )

--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReport.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReport.java
@@ -212,6 +212,10 @@ public class PmdReport
                 if ( skipEmptyReport )
                 {
                     result = reportListener.hasViolations();
+                    if ( result )
+                    {
+                        getLog().debug("Skipping Report as skipEmptyReport is true and there are no PMD violations.");
+                    }
                 }
             }
             catch ( MavenReportException e )

--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReport.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReport.java
@@ -58,7 +58,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Properties;
 import java.util.ResourceBundle;
 
@@ -135,6 +134,9 @@ public class PmdReport
     @Component
     private ResourceManager locator;
 
+    /** The PMD report listener for collecting violations. */
+    private PmdReportListener reportListener;
+
     /**
      * {@inheritDoc}
      */
@@ -178,11 +180,6 @@ public class PmdReport
     private void execute( Locale locale )
         throws MavenReportException
     {
-        //configure ResourceManager
-        locator.addSearchPath( FileResourceLoader.ID, project.getFile().getParentFile().getAbsolutePath() );
-        locator.addSearchPath( "url", "" );
-        locator.setOutputDirectory( targetDirectory );
-
         if ( !skip && canGenerateReport() )
         {
             ClassLoader origLoader = Thread.currentThread().getContextClassLoader();
@@ -192,7 +189,7 @@ public class PmdReport
 
                 Report report = generateReport( locale );
 
-                if ( !isHtml() )
+                if ( !isHtml() && !isXml() )
                 {
                     writeNonHtml( report );
                 }
@@ -204,16 +201,61 @@ public class PmdReport
         }
     }
 
-    private Report generateReport( Locale locale )
+    public boolean canGenerateReport()
+    {
+        boolean result = super.canGenerateReport();
+        if ( result )
+        {
+            try
+            {
+                executePmdWithClassloader();
+                if ( skipEmptyReport )
+                {
+                    result = reportListener.hasViolations();
+                }
+            }
+            catch ( MavenReportException e )
+            {
+                throw new RuntimeException( e );
+            }
+        }
+        return result;
+    }
+
+    private void executePmdWithClassloader()
         throws MavenReportException
     {
-        Sink sink = getSink();
+        ClassLoader origLoader = Thread.currentThread().getContextClassLoader();
+        try
+        {
+            Thread.currentThread().setContextClassLoader( this.getClass().getClassLoader() );
+            executePmd();
+        }
+        finally
+        {
+            Thread.currentThread().setContextClassLoader( origLoader );
+        }
+    }
 
+    private void executePmd()
+        throws MavenReportException
+    {
+        if ( reportListener != null )
+        {
+            // PMD has already been run
+            getLog().debug( "PMD has already been run - skipping redundant execution." );
+            return;
+        }
+
+        //configure ResourceManager
+        locator.addSearchPath( FileResourceLoader.ID, project.getFile().getParentFile().getAbsolutePath() );
+        locator.addSearchPath( "url", "" );
+        locator.setOutputDirectory( targetDirectory );
+
+        reportListener = new PmdReportListener();
         PMDConfiguration pmdConfiguration = getPMDConfiguration();
-        final PmdReportListener reportSink = new PmdReportListener( getLog(), sink, getBundle( locale ), aggregate );
         RuleContext ruleContext = new RuleContext();
-        ruleContext.getReport().addListener( reportSink );
-        reportSink.beginDocument();
+        ruleContext.getReport().addListener( reportListener );
 
         RuleSetFactory ruleSetFactory = new RuleSetFactory();
         ruleSetFactory.setMinimumPriority( RulePriority.valueOf( this.minimumPriority ) );
@@ -243,14 +285,17 @@ public class PmdReport
         }
         pmdConfiguration.setRuleSets( StringUtils.join( sets, "," ) );
 
-        Map<File, PmdFileInfo> files;
         try
         {
-            files = getFilesToProcess();
-            if ( files.isEmpty() && !"java".equals( language ) )
+            if ( filesToProcess == null )
+            {
+                filesToProcess = getFilesToProcess();
+            }
+
+            if ( filesToProcess.isEmpty() && !"java".equals( language ) )
             {
                 getLog().warn(
-                    "No files found to process. Did you add your additional source folders like javascript? (see also build-helper-maven-plugin)" );
+                        "No files found to process. Did you add your additional source folders like javascript? (see also build-helper-maven-plugin)" );
             }
         }
         catch ( IOException e )
@@ -259,7 +304,7 @@ public class PmdReport
         }
 
         String encoding = getSourceEncoding();
-        if ( StringUtils.isEmpty( encoding ) && !files.isEmpty() )
+        if ( StringUtils.isEmpty( encoding ) && !filesToProcess.isEmpty() )
         {
             getLog().warn( "File encoding has not been set, using platform encoding " + ReaderFactory.FILE_ENCODING
                                + ", i.e. build is platform dependent!" );
@@ -267,32 +312,56 @@ public class PmdReport
         }
         pmdConfiguration.setSourceEncoding( encoding );
 
-        reportSink.setFiles( files );
-        List<DataSource> dataSources = new ArrayList<DataSource>( files.size() );
-        for ( File f : files.keySet() )
+        List<DataSource> dataSources = new ArrayList<DataSource>( filesToProcess.size() );
+        for ( File f : filesToProcess.keySet() )
         {
             dataSources.add( new FileDataSource( f ) );
         }
 
         try
         {
+            getLog().debug( "Executing PMD..." );
+
             PMD.processFiles( pmdConfiguration, ruleSetFactory, dataSources, ruleContext, Collections.<Renderer> emptyList() );
+
+            if ( getLog().isDebugEnabled() )
+            {
+                getLog().debug( "PMD finished. Found " + reportListener.getViolations().size() + " violations." );
+            }
         }
         catch ( Exception e )
         {
             getLog().warn( "Failure executing PMD: " + e.getLocalizedMessage(), e );
         }
 
+        // if format is XML, we need to output it even if the file list is empty or we have no violations
+        // so the "check" goals can check for violations
+        if ( isXml() && reportListener != null )
+        {
+            writeNonHtml( reportListener.asReport() );
+        }
+    }
+
+    private Report generateReport( Locale locale )
+        throws MavenReportException
+    {
+        Sink sink = getSink();
+        PmdReportGenerator renderer = new PmdReportGenerator( getLog(), sink, getBundle( locale ), aggregate );
+        renderer.setFiles( filesToProcess );
+        renderer.setViolations( reportListener.getViolations() );
+
         try
         {
-            reportSink.endDocument();
+            renderer.beginDocument();
+            renderer.render();
+            renderer.endDocument();
         }
         catch ( IOException e )
         {
             getLog().warn( "Failure creating the report: " + e.getLocalizedMessage(), e );
         }
 
-        return reportSink.asReport();
+        return reportListener.asReport();
     }
 
     /**

--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReportGenerator.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReportGenerator.java
@@ -1,0 +1,365 @@
+package org.apache.maven.plugin.pmd;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+import net.sourceforge.pmd.RuleViolation;
+
+import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.util.StringUtils;
+
+/**
+ * Render the PMD violations into Doxia events.
+ *
+ * @author Brett Porter
+ * @version $Id$
+ */
+public class PmdReportGenerator {
+    private Log log;
+
+    private Sink sink;
+
+    private String currentFilename;
+
+    private ResourceBundle bundle;
+
+    private HashSet<RuleViolation> violations = new HashSet<RuleViolation>();
+
+    private boolean aggregate;
+
+    // The number of erroneous files
+    private int fileCount = 0;
+
+    private Map<File, PmdFileInfo> files;
+
+//    private List<Metric> metrics = new ArrayList<Metric>();
+
+    public PmdReportGenerator( Log log, Sink sink, ResourceBundle bundle, boolean aggregate )
+    {
+        this.log = log;
+        this.sink = sink;
+        this.bundle = bundle;
+        this.aggregate = aggregate;
+    }
+
+    private String getTitle()
+    {
+        return bundle.getString( "report.pmd.title" );
+    }
+
+    public void setViolations( Collection<RuleViolation> violations )
+    {
+        this.violations = new HashSet<RuleViolation>( violations );
+    }
+
+    public List<RuleViolation> getViolations()
+    {
+        return new ArrayList<RuleViolation>( violations );
+    }
+
+//    public List<Metric> getMetrics()
+//    {
+//        return metrics;
+//    }
+//
+//    public void setMetrics( List<Metric> metrics )
+//    {
+//        this.metrics = metrics;
+//    }
+
+    private void startFileSection( String currentFilename, PmdFileInfo fileInfo )
+    {
+        sink.section2();
+        sink.sectionTitle2();
+
+        // prepare the filename
+        this.currentFilename = currentFilename;
+        if ( fileInfo != null && fileInfo.getSourceDirectory() != null )
+        {
+            this.currentFilename =
+                StringUtils.substring( currentFilename, fileInfo.getSourceDirectory().getAbsolutePath().length() + 1 );
+        }
+        this.currentFilename = StringUtils.replace( this.currentFilename, "\\", "/" );
+
+        String title = this.currentFilename;
+        if ( aggregate && fileInfo != null && fileInfo.getProject() != null )
+        {
+            title = fileInfo.getProject().getName() + " - " + this.currentFilename;
+        }
+        sink.text( title );
+        sink.sectionTitle2_();
+
+        sink.table();
+        sink.tableRow();
+        sink.tableHeaderCell();
+        sink.text( bundle.getString( "report.pmd.column.violation" ) );
+        sink.tableHeaderCell_();
+        sink.tableHeaderCell();
+        sink.text( bundle.getString( "report.pmd.column.line" ) );
+        sink.tableHeaderCell_();
+        sink.tableRow_();
+    }
+
+    private void endFileSection()
+    {
+        sink.table_();
+        sink.section2_();
+    }
+
+    private void processSingleRuleViolation( RuleViolation ruleViolation, PmdFileInfo fileInfo )
+    {
+        sink.tableRow();
+        sink.tableCell();
+        sink.text( ruleViolation.getDescription() );
+        sink.tableCell_();
+        sink.tableCell();
+
+        int beginLine = ruleViolation.getBeginLine();
+        outputLineLink( beginLine, fileInfo );
+        int endLine = ruleViolation.getEndLine();
+        if ( endLine != beginLine )
+        {
+            sink.text( " - " );
+            outputLineLink( endLine, fileInfo );
+        }
+
+        sink.tableCell_();
+        sink.tableRow_();
+    }
+
+    // PMD might run the analysis multi-threaded, so the violations might be reported
+    // out of order. We sort them here by filename and line number before writing them to
+    // the report.
+    private void processViolations()
+        throws IOException
+    {
+        fileCount = files.size();
+        ArrayList<RuleViolation> violations2 = new ArrayList<RuleViolation>( violations );
+        Collections.sort( violations2, new Comparator<RuleViolation>()
+        {
+            /** {@inheritDoc} */
+            public int compare( RuleViolation o1, RuleViolation o2 )
+            {
+                int filenames = o1.getFilename().compareTo( o2.getFilename() );
+                if ( filenames == 0 )
+                {
+                    return o1.getBeginLine() - o2.getBeginLine();
+                }
+                else
+                {
+                    return filenames;
+                }
+            }
+        } );
+
+        boolean fileSectionStarted = false;
+        String previousFilename = null;
+        for ( RuleViolation ruleViolation : violations2 )
+        {
+            String currentFn = ruleViolation.getFilename();
+            File canonicalFilename = new File( currentFn ).getCanonicalFile();
+            PmdFileInfo fileInfo = files.get( canonicalFilename );
+            if ( fileInfo == null )
+            {
+                log.warn( "Couldn't determine PmdFileInfo for file " + currentFn + " (canonical: " + canonicalFilename
+                              + "). XRef links won't be available." );
+            }
+
+            if ( !currentFn.equalsIgnoreCase( previousFilename ) && fileSectionStarted )
+            {
+                endFileSection();
+                fileSectionStarted = false;
+            }
+            if ( !fileSectionStarted )
+            {
+                startFileSection( currentFn, fileInfo );
+                fileSectionStarted = true;
+            }
+
+            processSingleRuleViolation( ruleViolation, fileInfo );
+
+            previousFilename = currentFn;
+        }
+
+        if ( fileSectionStarted )
+        {
+            endFileSection();
+        }
+    }
+
+    private void outputLineLink( int line, PmdFileInfo fileInfo )
+    {
+        String xrefLocation = null;
+        if ( fileInfo != null )
+        {
+            xrefLocation = fileInfo.getXrefLocation();
+        }
+
+        if ( xrefLocation != null )
+        {
+            sink.link( xrefLocation + "/" + currentFilename.replaceAll( "\\.java$", ".html" ) + "#" + line );
+        }
+        sink.text( String.valueOf( line ) );
+        if ( xrefLocation != null )
+        {
+            sink.link_();
+        }
+    }
+
+    public void beginDocument()
+    {
+        sink.head();
+        sink.title();
+        sink.text( getTitle() );
+        sink.title_();
+        sink.head_();
+
+        sink.body();
+
+        sink.section1();
+        sink.sectionTitle1();
+        sink.text( getTitle() );
+        sink.sectionTitle1_();
+
+        sink.paragraph();
+        sink.text( bundle.getString( "report.pmd.pmdlink" ) + " " );
+        sink.link( "http://pmd.sourceforge.net/" );
+        sink.text( "PMD" );
+        sink.link_();
+        sink.text( " " + AbstractPmdReport.getPmdVersion() + "." );
+        sink.paragraph_();
+
+        sink.section1_();
+
+        // TODO overall summary
+
+        sink.section1();
+        sink.sectionTitle1();
+        sink.text( bundle.getString( "report.pmd.files" ) );
+        sink.sectionTitle1_();
+
+        // TODO files summary
+    }
+
+/*
+    private void processMetrics()
+    {
+        if ( metrics.size() == 0 )
+        {
+            return;
+        }
+
+        sink.section1();
+        sink.sectionTitle1();
+        sink.text( "Metrics" );
+        sink.sectionTitle1_();
+
+        sink.table();
+        sink.tableRow();
+        sink.tableHeaderCell();
+        sink.text( "Name" );
+        sink.tableHeaderCell_();
+        sink.tableHeaderCell();
+        sink.text( "Count" );
+        sink.tableHeaderCell_();
+        sink.tableHeaderCell();
+        sink.text( "High" );
+        sink.tableHeaderCell_();
+        sink.tableHeaderCell();
+        sink.text( "Low" );
+        sink.tableHeaderCell_();
+        sink.tableHeaderCell();
+        sink.text( "Average" );
+        sink.tableHeaderCell_();
+        sink.tableRow_();
+
+        for ( Metric met : metrics )
+        {
+            sink.tableRow();
+            sink.tableCell();
+            sink.text( met.getMetricName() );
+            sink.tableCell_();
+            sink.tableCell();
+            sink.text( String.valueOf( met.getCount() ) );
+            sink.tableCell_();
+            sink.tableCell();
+            sink.text( String.valueOf( met.getHighValue() ) );
+            sink.tableCell_();
+            sink.tableCell();
+            sink.text( String.valueOf( met.getLowValue() ) );
+            sink.tableCell_();
+            sink.tableCell();
+            sink.text( String.valueOf( met.getAverage() ) );
+            sink.tableCell_();
+            sink.tableRow_();
+        }
+        sink.table_();
+        sink.section1_();
+    }
+*/
+
+    public void render()
+        throws IOException
+    {
+        processViolations();
+    }
+
+    public void endDocument()
+        throws IOException
+    {
+        if ( fileCount == 0 )
+        {
+            sink.paragraph();
+            sink.text( bundle.getString( "report.pmd.noProblems" ) );
+            sink.paragraph_();
+        }
+
+        sink.section1_();
+
+        // The Metrics report useless with the current PMD metrics impl.
+        // For instance, run the coupling ruleset and you will get a boatload
+        // of excessive imports metrics, none of which is really any use.
+        // TODO Determine if we are going to just ignore metrics.
+
+//        processMetrics();
+
+        sink.body_();
+
+        sink.flush();
+
+        sink.close();
+    }
+
+    public void setFiles( Map<File, PmdFileInfo> files )
+    {
+        this.files = files;
+    }
+}

--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReportListener.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReportListener.java
@@ -19,65 +19,24 @@ package org.apache.maven.plugin.pmd;
  * under the License.
  */
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
 
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.ReportListener;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.stat.Metric;
 
-import org.apache.maven.doxia.sink.Sink;
-import org.apache.maven.plugin.logging.Log;
-import org.codehaus.plexus.util.StringUtils;
-
 /**
- * Handle events from PMD, converting them into Doxia events.
- *
- * @author Brett Porter
- * @version $Id$
+ * Handle events from PMD and collect violations.
  */
 public class PmdReportListener
     implements ReportListener
 {
-    private Log log;
-
-    private Sink sink;
-
-    private String currentFilename;
-
-    private ResourceBundle bundle;
-
     private HashSet<RuleViolation> violations = new HashSet<RuleViolation>();
 
-    private boolean aggregate;
-
-    // The number of erroneous files
-    private int fileCount = 0;
-
-    private Map<File, PmdFileInfo> files;
-
 //    private List<Metric> metrics = new ArrayList<Metric>();
-
-    public PmdReportListener( Log log, Sink sink, ResourceBundle bundle, boolean aggregate )
-    {
-        this.log = log;
-        this.sink = sink;
-        this.bundle = bundle;
-        this.aggregate = aggregate;
-    }
-
-    private String getTitle()
-    {
-        return bundle.getString( "report.pmd.title" );
-    }
 
     /**
      * {@inheritDoc}
@@ -92,6 +51,11 @@ public class PmdReportListener
         return new ArrayList<RuleViolation>( violations );
     }
 
+    public boolean hasViolations()
+    {
+        return !violations.isEmpty();
+    }
+
     /**
      * Create a new single report with all violations for further rendering into other formats than HTML.
      */
@@ -104,145 +68,6 @@ public class PmdReportListener
         return report;
     }
 
-    private void startFileSection( String currentFilename, PmdFileInfo fileInfo )
-    {
-        sink.section2();
-        sink.sectionTitle2();
-
-        // prepare the filename
-        this.currentFilename = currentFilename;
-        if ( fileInfo != null && fileInfo.getSourceDirectory() != null )
-        {
-            this.currentFilename =
-                StringUtils.substring( currentFilename, fileInfo.getSourceDirectory().getAbsolutePath().length() + 1 );
-        }
-        this.currentFilename = StringUtils.replace( this.currentFilename, "\\", "/" );
-
-        String title = this.currentFilename;
-        if ( aggregate && fileInfo != null && fileInfo.getProject() != null )
-        {
-            title = fileInfo.getProject().getName() + " - " + this.currentFilename;
-        }
-        sink.text( title );
-        sink.sectionTitle2_();
-
-        sink.table();
-        sink.tableRow();
-        sink.tableHeaderCell();
-        sink.text( bundle.getString( "report.pmd.column.violation" ) );
-        sink.tableHeaderCell_();
-        sink.tableHeaderCell();
-        sink.text( bundle.getString( "report.pmd.column.line" ) );
-        sink.tableHeaderCell_();
-        sink.tableRow_();
-    }
-
-    private void endFileSection()
-    {
-        sink.table_();
-        sink.section2_();
-    }
-
-    private void processSingleRuleViolation( RuleViolation ruleViolation, PmdFileInfo fileInfo )
-    {
-        sink.tableRow();
-        sink.tableCell();
-        sink.text( ruleViolation.getDescription() );
-        sink.tableCell_();
-        sink.tableCell();
-
-        int beginLine = ruleViolation.getBeginLine();
-        outputLineLink( beginLine, fileInfo );
-        int endLine = ruleViolation.getEndLine();
-        if ( endLine != beginLine )
-        {
-            sink.text( " - " );
-            outputLineLink( endLine, fileInfo );
-        }
-
-        sink.tableCell_();
-        sink.tableRow_();
-    }
-
-    // PMD might run the analysis multi-threaded, so the violations might be reported
-    // out of order. We sort them here by filename and line number before writing them to
-    // the report.
-    private void processViolations()
-        throws IOException
-    {
-        fileCount = files.size();
-        ArrayList<RuleViolation> violations2 = new ArrayList<RuleViolation>( violations );
-        Collections.sort( violations2, new Comparator<RuleViolation>()
-        {
-            /** {@inheritDoc} */
-            public int compare( RuleViolation o1, RuleViolation o2 )
-            {
-                int filenames = o1.getFilename().compareTo( o2.getFilename() );
-                if ( filenames == 0 )
-                {
-                    return o1.getBeginLine() - o2.getBeginLine();
-                }
-                else
-                {
-                    return filenames;
-                }
-            }
-        } );
-
-        boolean fileSectionStarted = false;
-        String previousFilename = null;
-        for ( RuleViolation ruleViolation : violations2 )
-        {
-            String currentFn = ruleViolation.getFilename();
-            File canonicalFilename = new File( currentFn ).getCanonicalFile();
-            PmdFileInfo fileInfo = files.get( canonicalFilename );
-            if ( fileInfo == null )
-            {
-                log.warn( "Couldn't determine PmdFileInfo for file " + currentFn + " (canonical: " + canonicalFilename
-                              + "). XRef links won't be available." );
-            }
-
-            if ( !currentFn.equalsIgnoreCase( previousFilename ) && fileSectionStarted )
-            {
-                endFileSection();
-                fileSectionStarted = false;
-            }
-            if ( !fileSectionStarted )
-            {
-                startFileSection( currentFn, fileInfo );
-                fileSectionStarted = true;
-            }
-
-            processSingleRuleViolation( ruleViolation, fileInfo );
-
-            previousFilename = currentFn;
-        }
-
-        if ( fileSectionStarted )
-        {
-            endFileSection();
-        }
-    }
-
-    private void outputLineLink( int line, PmdFileInfo fileInfo )
-    {
-        String xrefLocation = null;
-        if ( fileInfo != null )
-        {
-            xrefLocation = fileInfo.getXrefLocation();
-        }
-
-        if ( xrefLocation != null )
-        {
-            sink.link( xrefLocation + "/" + currentFilename.replaceAll( "\\.java$", ".html" ) + "#" + line );
-        }
-        sink.text( String.valueOf( line ) );
-        if ( xrefLocation != null )
-        {
-            sink.link_();
-        }
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -253,130 +78,5 @@ public class PmdReportListener
 //            // Skip metrics which have no data
 //            metrics.add( metric );
 //        }
-    }
-
-    public void beginDocument()
-    {
-        sink.head();
-        sink.title();
-        sink.text( getTitle() );
-        sink.title_();
-        sink.head_();
-
-        sink.body();
-
-        sink.section1();
-        sink.sectionTitle1();
-        sink.text( getTitle() );
-        sink.sectionTitle1_();
-
-        sink.paragraph();
-        sink.text( bundle.getString( "report.pmd.pmdlink" ) + " " );
-        sink.link( "http://pmd.sourceforge.net/" );
-        sink.text( "PMD" );
-        sink.link_();
-        sink.text( " " + AbstractPmdReport.getPmdVersion() + "." );
-        sink.paragraph_();
-
-        sink.section1_();
-
-        // TODO overall summary
-
-        sink.section1();
-        sink.sectionTitle1();
-        sink.text( bundle.getString( "report.pmd.files" ) );
-        sink.sectionTitle1_();
-
-        // TODO files summary
-    }
-
-/*
-    private void processMetrics()
-    {
-        if ( metrics.size() == 0 )
-        {
-            return;
-        }
-
-        sink.section1();
-        sink.sectionTitle1();
-        sink.text( "Metrics" );
-        sink.sectionTitle1_();
-
-        sink.table();
-        sink.tableRow();
-        sink.tableHeaderCell();
-        sink.text( "Name" );
-        sink.tableHeaderCell_();
-        sink.tableHeaderCell();
-        sink.text( "Count" );
-        sink.tableHeaderCell_();
-        sink.tableHeaderCell();
-        sink.text( "High" );
-        sink.tableHeaderCell_();
-        sink.tableHeaderCell();
-        sink.text( "Low" );
-        sink.tableHeaderCell_();
-        sink.tableHeaderCell();
-        sink.text( "Average" );
-        sink.tableHeaderCell_();
-        sink.tableRow_();
-
-        for ( Metric met : metrics )
-        {
-            sink.tableRow();
-            sink.tableCell();
-            sink.text( met.getMetricName() );
-            sink.tableCell_();
-            sink.tableCell();
-            sink.text( String.valueOf( met.getCount() ) );
-            sink.tableCell_();
-            sink.tableCell();
-            sink.text( String.valueOf( met.getHighValue() ) );
-            sink.tableCell_();
-            sink.tableCell();
-            sink.text( String.valueOf( met.getLowValue() ) );
-            sink.tableCell_();
-            sink.tableCell();
-            sink.text( String.valueOf( met.getAverage() ) );
-            sink.tableCell_();
-            sink.tableRow_();
-        }
-        sink.table_();
-        sink.section1_();
-    }
-*/
-
-    public void endDocument()
-        throws IOException
-    {
-        processViolations();
-
-        if ( fileCount == 0 )
-        {
-            sink.paragraph();
-            sink.text( bundle.getString( "report.pmd.noProblems" ) );
-            sink.paragraph_();
-        }
-
-        sink.section1_();
-
-        // The Metrics report useless with the current PMD metrics impl.
-        // For instance, run the coupling ruleset and you will get a boatload
-        // of excessive imports metrics, none of which is really any use.
-        // TODO Determine if we are going to just ignore metrics.
-
-//        processMetrics();
-
-        sink.body_();
-
-        sink.flush();
-
-        sink.close();
-    }
-
-    public void setFiles( Map<File, PmdFileInfo> files )
-    {
-        this.files = files;
     }
 }

--- a/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/CpdReportTest.java
+++ b/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/CpdReportTest.java
@@ -209,6 +209,33 @@ public class CpdReportTest
         assertNotNull( pmdCpdDocument );
     }
 
+    public void testSkipEmptyReportConfiguration()
+            throws Exception
+    {
+        File testPom = new File( getBasedir(), "src/test/resources/unit/empty-report/cpd-skip-empty-report-plugin-config.xml" );
+        CpdReport mojo = (CpdReport) lookupMojo( "cpd", testPom );
+        mojo.execute();
+
+        // verify the generated files do not exist because PMD was skipped
+        File generatedFile = new File( getBasedir(), "target/test/unit/empty-report/target/site/cpd.html" );
+        assertFalse( FileUtils.fileExists( generatedFile.getAbsolutePath() ) );
+    }
+
+    public void testEmptyReportConfiguration()
+            throws Exception
+    {
+        File testPom = new File( getBasedir(), "src/test/resources/unit/empty-report/cpd-empty-report-plugin-config.xml" );
+        CpdReport mojo = (CpdReport) lookupMojo( "cpd", testPom );
+        mojo.execute();
+
+        // verify the generated files do exist, even if there are no violations
+        File generatedFile = new File( getBasedir(), "target/test/unit/empty-report/target/site/cpd.html" );
+        assertTrue( FileUtils.fileExists( generatedFile.getAbsolutePath() ) );
+        String str = readFile( new File( getBasedir(), "target/test/unit/empty-report/target/site/cpd.html" ) );
+        assertTrue( str.toLowerCase().indexOf( "Hello.java".toLowerCase() ) == -1 );
+    }
+
+
     public static class MockCpd
         extends CPD
     {

--- a/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/PmdReportTest.java
+++ b/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/PmdReportTest.java
@@ -224,6 +224,32 @@ public class PmdReportTest
         assertFalse( FileUtils.fileExists( generatedFile.getAbsolutePath() ) );
     }
 
+    public void testSkipEmptyReportConfiguration()
+        throws Exception
+    {
+        File testPom = new File( getBasedir(), "src/test/resources/unit/empty-report/skip-empty-report-plugin-config.xml" );
+        PmdReport mojo = (PmdReport) lookupMojo( "pmd", testPom );
+        mojo.execute();
+
+        // verify the generated files do not exist because PMD was skipped
+        File generatedFile = new File( getBasedir(), "target/test/unit/empty-report/target/site/pmd.html" );
+        assertFalse( FileUtils.fileExists( generatedFile.getAbsolutePath() ) );
+    }
+
+    public void testEmptyReportConfiguration()
+            throws Exception
+    {
+        File testPom = new File( getBasedir(), "src/test/resources/unit/empty-report/empty-report-plugin-config.xml" );
+        PmdReport mojo = (PmdReport) lookupMojo( "pmd", testPom );
+        mojo.execute();
+
+        // verify the generated files do exist, even if there are no violations
+        File generatedFile = new File( getBasedir(), "target/test/unit/empty-report/target/site/pmd.html" );
+        assertTrue( FileUtils.fileExists( generatedFile.getAbsolutePath() ) );
+        String str = readFile( new File( getBasedir(), "target/test/unit/empty-report/target/site/pmd.html" ) );
+        assertTrue( str.toLowerCase().indexOf( "Hello.java".toLowerCase() ) == -1 );
+    }
+
     public void testInvalidFormat()
         throws Exception
     {

--- a/maven-pmd-plugin/src/test/resources/unit/empty-report/cpd-empty-report-plugin-config.xml
+++ b/maven-pmd-plugin/src/test/resources/unit/empty-report/cpd-empty-report-plugin-config.xml
@@ -1,0 +1,63 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>skip-report.configuration</groupId>
+  <artifactId>skip-report-configuration</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <inceptionYear>2013</inceptionYear>
+  <name>Maven PMD Plugin Skip Report Configuration Test</name>
+  <url>http://maven.apache.org</url>
+  <build>
+    <finalName>skip-report-configuration</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugin.pmd.stubs.CustomConfigurationMavenProjectStub"/>
+          <outputDirectory>${basedir}/target/test/unit/empty-report/target/site</outputDirectory>
+          <targetDirectory>${basedir}/target/test/unit/empty-report/target</targetDirectory>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/src/test/resources/unit/empty-report/java/</compileSourceRoot>
+          </compileSourceRoots>
+          <sourceEncoding>UTF-8</sourceEncoding>
+          <minimumTokens>100</minimumTokens>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>pmd</groupId>
+            <artifactId>pmd</artifactId>
+            <version>5.0.4</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/maven-pmd-plugin/src/test/resources/unit/empty-report/cpd-skip-empty-report-plugin-config.xml
+++ b/maven-pmd-plugin/src/test/resources/unit/empty-report/cpd-skip-empty-report-plugin-config.xml
@@ -1,0 +1,64 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>skip-report.configuration</groupId>
+  <artifactId>skip-report-configuration</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <inceptionYear>2013</inceptionYear>
+  <name>Maven PMD Plugin Skip Report Configuration Test</name>
+  <url>http://maven.apache.org</url>
+  <build>
+    <finalName>skip-report-configuration</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugin.pmd.stubs.CustomConfigurationMavenProjectStub"/>
+          <outputDirectory>${basedir}/target/test/unit/empty-report/target/site</outputDirectory>
+          <targetDirectory>${basedir}/target/test/unit/empty-report/target</targetDirectory>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/src/test/resources/unit/empty-report/java/</compileSourceRoot>
+          </compileSourceRoots>
+          <sourceEncoding>UTF-8</sourceEncoding>
+          <minimumTokens>100</minimumTokens>
+          <skipEmptyReport>true</skipEmptyReport>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>pmd</groupId>
+            <artifactId>pmd</artifactId>
+            <version>5.0.4</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/maven-pmd-plugin/src/test/resources/unit/empty-report/empty-report-plugin-config.xml
+++ b/maven-pmd-plugin/src/test/resources/unit/empty-report/empty-report-plugin-config.xml
@@ -1,0 +1,62 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>skip-report.configuration</groupId>
+  <artifactId>skip-report-configuration</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <inceptionYear>2013</inceptionYear>
+  <name>Maven PMD Plugin Skip Report Configuration Test</name>
+  <url>http://maven.apache.org</url>
+  <build>
+    <finalName>skip-report-configuration</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugin.pmd.stubs.CustomConfigurationMavenProjectStub"/>
+          <outputDirectory>${basedir}/target/test/unit/empty-report/target/site</outputDirectory>
+          <targetDirectory>${basedir}/target/test/unit/empty-report/target</targetDirectory>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/src/test/resources/unit/empty-report/java/</compileSourceRoot>
+          </compileSourceRoots>
+          <sourceEncoding>UTF-8</sourceEncoding>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>pmd</groupId>
+            <artifactId>pmd</artifactId>
+            <version>5.0.4</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/maven-pmd-plugin/src/test/resources/unit/empty-report/java/def/Hello.java
+++ b/maven-pmd-plugin/src/test/resources/unit/empty-report/java/def/Hello.java
@@ -1,0 +1,28 @@
+package def;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Hello
+{
+    public static void main( String[] args )
+    {
+        System.out.println( args[0] );
+    }
+}

--- a/maven-pmd-plugin/src/test/resources/unit/empty-report/skip-empty-report-plugin-config.xml
+++ b/maven-pmd-plugin/src/test/resources/unit/empty-report/skip-empty-report-plugin-config.xml
@@ -1,0 +1,63 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>skip-report.configuration</groupId>
+  <artifactId>skip-report-configuration</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <inceptionYear>2013</inceptionYear>
+  <name>Maven PMD Plugin Skip Report Configuration Test</name>
+  <url>http://maven.apache.org</url>
+  <build>
+    <finalName>skip-report-configuration</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugin.pmd.stubs.CustomConfigurationMavenProjectStub"/>
+          <outputDirectory>${basedir}/target/test/unit/empty-report/target/site</outputDirectory>
+          <targetDirectory>${basedir}/target/test/unit/empty-report/target</targetDirectory>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/src/test/resources/unit/empty-report/java/</compileSourceRoot>
+          </compileSourceRoots>
+          <sourceEncoding>UTF-8</sourceEncoding>
+          <skipEmptyReport>true</skipEmptyReport>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>pmd</groupId>
+            <artifactId>pmd</artifactId>
+            <version>5.0.4</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>


### PR DESCRIPTION
- The report generation for both PMD and CPD is split from the actual
  execution of these tools.
- PMD and CPD are now executed already when canGenerateReport() is called.
- The new parameter is called "skipEmptyReport" and is by default "false"
  to remain backwards compatibility.

Please note, that the new parameter is called "skipEmptyReport" and it is by default **not true** to be backwards compatible.
However, thinking over, I guess it's not a big deal to change the behaviour here and it seems to be a better default conventional
configuration.
- https://jira.codehaus.org/browse/MPMD-168
- `mvn clean integration-test -Prun-its` worked fine for me.
