### PR TITLE
[MJAR-170] make the jar classifier customizable via property maven.jar.classifier

### DIFF
--- a/maven-jar-plugin/src/main/java/org/apache/maven/plugin/jar/JarMojo.java
+++ b/maven-jar-plugin/src/main/java/org/apache/maven/plugin/jar/JarMojo.java
@@ -48,7 +48,7 @@ public class JarMojo
      * If this is not given,it will merely be written to the output directory
      * according to the finalName.
      */
-    @Parameter
+    @Parameter( property = "maven.jar.classifier", defaultValue = "" )
     private String classifier;
 
     protected String getClassifier()


### PR DESCRIPTION
tested with the following snippet in my pom.xml and it works:

``` xml
<properties>
        <maven.jar.classifier>jdk6</maven.jar.classifier>
</properties>

<build>
        <plugins>
                <plugin>
                        <artifactId>maven-jar-plugin</artifactId>
                        <version>2.5-SNAPSHOT</version> <!-- local patched snapshot version -->
                </plugin>
        </plugins>
</build>
```
