### PR TITLE
[MJAVADOC-376] make the javadoc classifier customizable via property maven.javadoc.classifier

### DIFF
--- a/maven-javadoc-plugin/src/main/java/org/apache/maven/plugin/javadoc/JavadocJar.java
+++ b/maven-javadoc-plugin/src/main/java/org/apache/maven/plugin/javadoc/JavadocJar.java
@@ -150,6 +150,12 @@ public class JavadocJar
     @Parameter( defaultValue = "false" )
     private boolean useDefaultManifestFile;
 
+    /**
+     * @since 2.9.2
+     */
+    @Parameter( property = "maven.javadoc.classifier", defaultValue = "javadoc" )
+    protected String classifier;
+
     /** {@inheritDoc} */
     public void execute()
         throws MojoExecutionException
@@ -223,7 +229,7 @@ public class JavadocJar
      */
     protected String getClassifier()
     {
-        return "javadoc";
+        return classifier;
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
finally all tests are passing, and tested with the following snippet in my pom.xml and it works:

``` xml
<properties>
        <maven.javadoc.classifier>javadoc-jdk6</maven.javadoc.classifier>
</properties>

<build>
        <plugins>
                <plugin>
                        <artifactId>maven-javadoc-plugin</artifactId>
                        <version>2.9.2-SNAPSHOT</version> <!-- local patched snapshot version -->
                </plugin>
        </plugins>
</build>
```
