### PR TITLE
PMD plugin side fix for PMD bug #1155.

### DIFF
--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReport.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReport.java
@@ -123,7 +123,7 @@ public class PmdReport
     /**
      * Controls whether the project's compile/test classpath should be passed to PMD to enable its type resolution
      * feature.
-     * 
+     *
      * @since 3.0
      */
     @Parameter( property = "pmd.typeResolution", defaultValue = "false" )
@@ -263,12 +263,16 @@ public class PmdReport
 
         RuleSetFactory ruleSetFactory = new RuleSetFactory();
         ruleSetFactory.setMinimumPriority( RulePriority.valueOf( this.minimumPriority ) );
-        String[] sets = new String[rulesets.length];
+
+        // Workaround for https://sourceforge.net/p/pmd/bugs/1155/: add a dummy ruleset.
+        String [] presentRulesets = rulesets.length > 0 ? rulesets : new String [] { "/rulesets/dummy.xml" };
+
+        String[] sets = new String[presentRulesets.length];
         try
         {
-            for ( int idx = 0; idx < rulesets.length; idx++ )
+            for ( int idx = 0; idx < presentRulesets.length; idx++ )
             {
-                String set = rulesets[idx];
+                String set = presentRulesets[idx];
                 getLog().debug( "Preparing ruleset: " + set );
                 RuleSetReferenceId id = new RuleSetReferenceId( set );
                 File ruleset = locator.getResourceAsFile( id.getRuleSetFileName(), getLocationTemp( set ) );

--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/rules/DummyRule.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/rules/DummyRule.java
@@ -1,0 +1,37 @@
+package org.apache.maven.plugin.pmd.rules;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.AbstractRule;
+
+/**
+ * A dummy rule that does nothing. Referenced from the Dummy ruleset
+ * to work around pmd bug #1155.
+ */
+public class DummyRule extends AbstractRule
+{
+    public void apply( List<? extends Node> nodes, RuleContext ctx )
+    {
+    }
+}

--- a/maven-pmd-plugin/src/main/resources/rulesets/dummy.xml
+++ b/maven-pmd-plugin/src/main/resources/rulesets/dummy.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<ruleset name="Dummy Ruleset"
+  xmlns="http://pmd.sf.net/ruleset/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+  xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+  <!--
+    Dummy ruleset to work around bug #1155 (no rule sets present) in pmd 5.0.x.
+  -->
+
+  <description>
+    Only a dummy rules that does nothing.
+  </description>
+
+  <!-- This can not be empty because the XSD requires at least one rule. -->
+  <rule name="DummyRule"
+        message="Dummy rule"
+        language="java"
+        class="org.apache.maven.plugin.pmd.rules.DummyRule" />
+</ruleset>


### PR DESCRIPTION
The PMD plugin crashes if the ruleset element in the POM is present but empty.
