### PR TITLE
MDEP-410, Add dependency:collect goal that does not download artifacts other than pom files.

### DIFF
--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/resolvers/CollectDependenciesMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/resolvers/CollectDependenciesMojo.java
@@ -1,0 +1,45 @@
+package org.apache.maven.plugins.dependency.resolvers;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Goal that collects the project dependencies from the repository.
+ * This goal requires Maven 3.0 or higher to function because it uses "requiresDependencyCollection".
+ * This means that it lists the groupId:artifactId:version information by downloading the pom files
+ * without downloading the actual artifacts such as jar files.
+ * This is very useful when full dependency resolution might fail due to projects which haven't been built yet.
+ * <p/>
+ * It is identical to {@link ResolveDependenciesMojo} except for using the requiresDependencyCollection annotation
+ * attribute instead of requiresDependencyResolution.
+ *
+ * @author <a href="mailto:epabst@gmail.com">Eric Pabst</a>
+ * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
+ * @version $Id$
+ * @since 3.0
+ */
+@Mojo( name = "collect", requiresDependencyCollection = ResolutionScope.TEST,
+       defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true )
+public class CollectDependenciesMojo extends ResolveDependenciesMojo
+{
+}

--- a/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/TestCollectMojo.java
+++ b/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/TestCollectMojo.java
@@ -1,0 +1,111 @@
+package org.apache.maven.plugins.dependency;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugins.dependency.resolvers.CollectDependenciesMojo;
+import org.apache.maven.plugins.dependency.utils.DependencyStatusSets;
+import org.apache.maven.plugin.testing.SilentLog;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.util.Set;
+
+public class TestCollectMojo
+    extends AbstractDependencyMojoTestCase
+{
+
+    protected void setUp()
+        throws Exception
+    {
+        // required for mojo lookups to work
+        super.setUp( "markers", false );
+    }
+
+    /**
+     * tests the proper discovery and configuration of the mojo
+     * 
+     * @throws Exception if a problem occurs
+     */
+    public void testCollectTestEnvironment()
+        throws Exception
+    {
+        File testPom = new File( getBasedir(), "target/test-classes/unit/collect-test/plugin-config.xml" );
+        CollectDependenciesMojo mojo = (CollectDependenciesMojo) lookupMojo( "collect", testPom );
+
+        assertNotNull( mojo );
+        assertNotNull( mojo.getProject() );
+        MavenProject project = mojo.getProject();
+
+        mojo.setSilent(true);
+        Set<Artifact> artifacts = this.stubFactory.getScopedArtifacts();
+        Set<Artifact> directArtifacts = this.stubFactory.getReleaseAndSnapshotArtifacts();
+        artifacts.addAll( directArtifacts );
+
+        project.setArtifacts( artifacts );
+        project.setDependencyArtifacts( directArtifacts );
+
+        mojo.execute();
+        DependencyStatusSets results = mojo.getResults();
+        assertNotNull(results);
+        assertEquals(artifacts.size(), results.getResolvedDependencies().size());
+    }
+
+    /**
+     * tests the proper discovery and configuration of the mojo
+     *
+     * @throws Exception if a problem occurs
+     */
+    public void testCollectTestEnvironment_excludeTransitive()
+        throws Exception
+    {
+        File testPom = new File( getBasedir(), "target/test-classes/unit/collect-test/plugin-config.xml" );
+        CollectDependenciesMojo mojo = (CollectDependenciesMojo) lookupMojo( "collect", testPom );
+
+        assertNotNull( mojo );
+        assertNotNull( mojo.getProject() );
+        MavenProject project = mojo.getProject();
+
+        mojo.setSilent(true);
+        Set<Artifact> artifacts = this.stubFactory.getScopedArtifacts();
+        Set<Artifact> directArtifacts = this.stubFactory.getReleaseAndSnapshotArtifacts();
+        artifacts.addAll( directArtifacts );
+
+        project.setArtifacts(artifacts);
+        project.setDependencyArtifacts(directArtifacts);
+
+        setVariableValueToObject( mojo, "excludeTransitive", Boolean.TRUE );
+
+        mojo.execute();
+        DependencyStatusSets results = mojo.getResults();
+        assertNotNull( results );
+        assertEquals( directArtifacts.size(), results.getResolvedDependencies().size() );
+    }
+
+    public void testSilent()
+        throws Exception
+    {
+        File testPom = new File( getBasedir(), "target/test-classes/unit/collect-test/plugin-config.xml" );
+        CollectDependenciesMojo mojo = (CollectDependenciesMojo) lookupMojo( "collect", testPom );
+        mojo.setSilent(false);
+
+        assertFalse( mojo.getLog() instanceof SilentLog );
+    } // TODO: Test skipping artifacts.
+}

--- a/maven-dependency-plugin/src/test/resources/its/collect/pom.xml
+++ b/maven-dependency-plugin/src/test/resources/its/collect/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+-->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>maven-dependency-plugin-it-parent</artifactId>
+    <version>1</version>
+  </parent>
+
+  <artifactId>maven-dependency-plugin-it-collect</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+  </dependencies>
+  <!--This must be set so the correct version is used for the IT test-->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>collect</id>
+            <goals>
+              <goal>collect</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-dependency-plugin/src/test/resources/unit/collect-test/plugin-config.xml
+++ b/maven-dependency-plugin/src/test/resources/unit/collect-test/plugin-config.xml
@@ -1,0 +1,38 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License. 
+ *
+-->
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugins.dependency.testUtils.stubs.DependencyProjectStub"/>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>2.0.4</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
It requires Maven 3 to function, but results in a warning if an earlier version of Maven.
