### PR TITLE
MCHANGES-376 Log level fix for ProjectUtils.

### DIFF
--- a/maven-changes-plugin/src/main/java/org/apache/maven/plugin/changes/ProjectUtils.java
+++ b/maven-changes-plugin/src/main/java/org/apache/maven/plugin/changes/ProjectUtils.java
@@ -57,10 +57,16 @@ public class ProjectUtils
 
             return false;
         }
-        else if ( ( project.getIssueManagement().getSystem() != null )
-            && !( project.getIssueManagement().getSystem().equalsIgnoreCase( issueManagementSystem ) ) )
+        else if ( ( project.getIssueManagement().getSystem() == null )
+            || ( project.getIssueManagement().getSystem().trim().equals("") ) )
         {
-            log.error( "The " + mojoResult + " only supports " + issueManagementSystem + ".  No " + mojoResult
+            log.error( "No System set in Issue Management. No " + mojoResult + " will be generated." );
+
+            return false;
+        }
+        else if ( !( project.getIssueManagement().getSystem().equalsIgnoreCase( issueManagementSystem ) ) )
+        {
+            log.debug( "The " + mojoResult + " only supports " + issueManagementSystem + ".  No " + mojoResult
                 + " will be generated." );
 
             return false;


### PR DESCRIPTION
This patch fixes the log level and distinguishes the exceptional case. With the previous code, when, for example, 'GitHub' is configured in pom.xml as issueManagement system, during the execution of the 'mvn site' goal, while the plugin starts generating report, it prompts two error lines for 'Trac' and 'JIRA' even without configuration errors.
