### PR TITLE
Fix SBT dependencies information

### DIFF
--- a/maven-project-info-reports-plugin/src/main/java/org/apache/maven/report/projectinfo/DependencyInformationReport.java
+++ b/maven-project-info-reports-plugin/src/main/java/org/apache/maven/report/projectinfo/DependencyInformationReport.java
@@ -180,7 +180,7 @@ public final class DependencyInformationReport
 
             // sbt
 
-            renderDependencyInfo( "SBT", new Formatter().format( "libraryDependencies += \"%s\" %%%% \"%s\" %% \"%s\"",
+            renderDependencyInfo( "SBT", new Formatter().format( "libraryDependencies += \"%s\" %% \"%s\" %% \"%s\"",
                                                                  groupId, artifactId, version ) );
 
             endSection();


### PR DESCRIPTION
With double '%' SBT tries to find the dependencies compiled with the
locally used Scala version[1]. Since most Maven projects doesn't use
Scala this results in errors like:

[warn] ::::::::::::::::::::::::::::::::::::::::::::::
[warn] :: UNRESOLVED DEPENDENCIES ::
[warn] ::::::::::::::::::::::::::::::::::::::::::::::
[warn] :: joda-time#joda-time_2.10;2.3: not found
[warn] ::::::::::::::::::::::::::::::::::::::::::::::

[1] http://www.scala-sbt.org/release/docs/Library-Management.html#Dependencies
