### PR TITLE
[MJAVADOC-398] Do not add classes from build output directory to classpath

### DIFF
--- a/maven-javadoc-plugin/src/main/java/org/apache/maven/plugin/javadoc/AbstractJavadocMojo.java
+++ b/maven-javadoc-plugin/src/main/java/org/apache/maven/plugin/javadoc/AbstractJavadocMojo.java
@@ -2436,8 +2436,6 @@ public abstract class AbstractJavadocMojo
         List<String> classpathElements = new ArrayList<String>();
         Map<String, Artifact> compileArtifactMap = new HashMap<String, Artifact>();
 
-        classpathElements.addAll( getProjectBuildOutputDirs( project ) );
-
         populateCompileArtifactMap( compileArtifactMap, getProjectArtifacts( project ) );
 
         if ( isAggregator() && project.isExecutionRoot() )


### PR DESCRIPTION
See http://jira.codehaus.org/browse/MJAVADOC-398

Project's classes on classpath can confuse javadoc tool in some
cases. The result can be either incorrect serialized-form.html
page or failure (in case of jdk8). See [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1113877) for more details.
