### PR TITLE
Upgarding to use latest PMD to support JDK 1.8 code base

### DIFF
--- a/maven-pmd-plugin/pom.xml
+++ b/maven-pmd-plugin/pom.xml
@@ -82,7 +82,7 @@ under the License.
   <properties>
     <mavenVersion>2.2.1</mavenVersion>
     <doxiaVersion>1.4</doxiaVersion>
-    <pmdVersion>5.0.5</pmdVersion>
+    <pmdVersion>5.1.1</pmdVersion>
     <sitePluginVersion>3.3</sitePluginVersion>
     <mavenPluginVersion>3.2</mavenPluginVersion>
     <projectInfoReportsPluginVersion>2.7</projectInfoReportsPluginVersion>
@@ -260,6 +260,22 @@ under the License.
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>enforce-bytecode-version</id>
+                    <configuration>
+                        <rules>
+                            <enforceBytecodeVersion>
+                                <maxJdkVersion>1.6</maxJdkVersion>
+                            </enforceBytecodeVersion>
+                        </rules>
+                        <fail>true</fail>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
PMD version 5.0.0 used in 3.1 version is not validating JDK 1.8 projects. Bumped PMD to 5.1.1 and changed enforcer plugin rules to do JDK check with 1.6 based on pmd pom.xml
