### PR TITLE
MPDF-66 maven-pdf-plugin puts project.properties into Velocity context.

### DIFF
--- a/maven-pdf-plugin/src/main/java/org/apache/maven/plugins/pdf/PdfMojo.java
+++ b/maven-pdf-plugin/src/main/java/org/apache/maven/plugins/pdf/PdfMojo.java
@@ -534,6 +534,13 @@ public class PdfMojo
             context.put( "generateTOC", generateTOC );
             context.put( "validate", validate);
 
+            // MPDF-66  Put any of the properties in directly into the Velocity context
+            // (code copied from /maven-site-plugin-3.3/src/main/java/org/apache/maven/plugins/site/AbstractSiteRenderingMojo.java)
+            for ( Map.Entry<Object, Object> entry : project.getProperties().entrySet() )
+            {
+                context.put( (String) entry.getKey(), entry.getValue() );
+            }
+
             final DocumentModel model = aggregate ? getDocumentModel( locale ) : null;
 
             try


### PR DESCRIPTION
It works. Are there any side effects to be expected by putting all project.properties into the renderer context?
