### PR TITLE
Fix file retreiving when using artifact in the reactor

### DIFF
--- a/maven-checkstyle-plugin/src/main/java/org/apache/maven/plugin/checkstyle/exec/DefaultCheckstyleExecutor.java
+++ b/maven-checkstyle-plugin/src/main/java/org/apache/maven/plugin/checkstyle/exec/DefaultCheckstyleExecutor.java
@@ -843,7 +843,14 @@ public class DefaultCheckstyleExecutor
             {
                 try
                 {
-                    resourceManager.addSearchPath( "jar", "jar:" + licenseArtifact.getFile().toURI().toURL() );
+                    if ( licenseArtifact.getFile().isDirectory() )
+                    {
+                        resourceManager.addSearchPath( "file", licenseArtifact.getFile().getAbsolutePath() );
+                    }
+                    else
+                    {
+                        resourceManager.addSearchPath( "jar", "jar:" + licenseArtifact.getFile().toURI().toURL() );
+                    }
                 }
                 catch ( MalformedURLException e )
                 {


### PR DESCRIPTION
If we add an artifact  as dependency which is used in the reactor, then a null pointer exception is thrown.
It's due to the fact that artifact file is not a jar but target/classes path.
Similar to https://jira.codehaus.org/browse/MDEP-187 https://jira.codehaus.org/browse/MDEP-98
