### PR TITLE
[MPMD-193] CPD's sourceEncoding not set since PMD 5.1.1 is used

### DIFF
--- a/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/CpdReportTest.java
+++ b/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/CpdReportTest.java
@@ -238,6 +238,30 @@ public class CpdReportTest
         assertTrue(!str.toLowerCase().contains("Hello.java".toLowerCase()));
     }
 
+    public void testCpdEncodingConfiguration()
+            throws Exception
+    {
+        String originalEncoding = System.getProperty( "file.encoding" );
+        try
+        {
+            System.setProperty( "file.encoding", "UTF-16" );
+
+            File testPom = new File( getBasedir(),
+                    "src/test/resources/unit/default-configuration/cpd-default-configuration-plugin-config.xml" );
+            CpdReport mojo = (CpdReport) lookupMojo( "cpd", testPom );
+            mojo.execute();
+
+            // check if the CPD files were generated
+            File generatedFile = new File( getBasedir(), "target/test/unit/default-configuration/target/cpd.xml" );
+            assertTrue( FileUtils.fileExists( generatedFile.getAbsolutePath() ) );
+            String str = readFile( generatedFile );
+            assertTrue(str.toLowerCase().contains("AppSample.java".toLowerCase()));
+        }
+        finally
+        {
+            System.setProperty( "file.encoding", originalEncoding );
+        }
+    }
 
     public static class MockCpd
         extends CPD

--- a/maven-pmd-plugin/src/test/resources/unit/default-configuration/cpd-encoding-configuration-plugin-config.xml
+++ b/maven-pmd-plugin/src/test/resources/unit/default-configuration/cpd-encoding-configuration-plugin-config.xml
@@ -1,0 +1,61 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>def.configuration</groupId>
+  <artifactId>cpd-encoding-configuration</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <inceptionYear>2006</inceptionYear>
+  <name>Maven CPD Plugin Encoding Configuration Test</name>
+  <url>http://maven.apache.org</url>
+  <build>
+    <finalName>default-configuration</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugin.pmd.stubs.DefaultConfigurationMavenProjectStub"/>
+          <outputDirectory>${basedir}/target/test/unit/default-configuration/target/site</outputDirectory>
+          <targetDirectory>${basedir}/target/test/unit/default-configuration/target</targetDirectory>
+          <format>xml</format>
+          <linkXRef>false</linkXRef>
+          <xrefLocation>${basedir}/target/test/unit/default-configuration/target/site/xref</xrefLocation>
+          <minimumTokens>100</minimumTokens>
+
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/src/test/resources/unit/default-configuration/</compileSourceRoot>
+          </compileSourceRoots>
+
+          <sourceEncoding>UTF-8</sourceEncoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>


### PR DESCRIPTION
That's just a unit test for https://jira.codehaus.org/browse/MPMD-193.
After upgrading to PMD 5.2.2 (https://jira.codehaus.org/browse/MPMD-195) this unit test should turn green.
