### PR TITLE
[MPMD-171] Rule properties are ignored when run under MPMD - unit test

### DIFF
--- a/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/PmdReportTest.java
+++ b/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/PmdReportTest.java
@@ -198,6 +198,10 @@ public class PmdReportTest
         assertTrue( "unnecessary constructor should not be triggered because of low priority",
                 !str.toLowerCase().contains("Avoid unnecessary constructors - the compiler will generate these for you".toLowerCase()));
 
+        // veryLongVariableNameWithViolation is really too long
+        assertTrue( str.toLowerCase().contains( "veryLongVariableNameWithViolation".toLowerCase() ) );
+        // notSoLongVariableName should not be reported
+        assertFalse( str.toLowerCase().contains( "notSoLongVariableName".toLowerCase() ) );
     }
 
     /**

--- a/maven-pmd-plugin/src/test/resources/unit/custom-configuration/custom/configuration/App.java
+++ b/maven-pmd-plugin/src/test/resources/unit/custom-configuration/custom/configuration/App.java
@@ -65,6 +65,10 @@ public class App
     public void testMethod( String unusedParam1, String unusedParam2 )
     {
         System.out.println( "Test method" );
+        String notSoLongVariableName = "a"; // just 21 characters, but threshold is 25 characters
+        String veryLongVariableNameWithViolation = "a"; // more than 25 characters
+        // so that the two variables are not reported as unused
+        System.out.println( notSoLongVariableName + veryLongVariableNameWithViolation );
     }
 
 }

--- a/maven-pmd-plugin/src/test/resources/unit/custom-configuration/resources/rulesets/custom.xml
+++ b/maven-pmd-plugin/src/test/resources/unit/custom-configuration/resources/rulesets/custom.xml
@@ -31,5 +31,11 @@ under the License.
   <rule ref="rulesets/java/controversial.xml/UnnecessaryConstructor" >
 	<priority>5</priority>
   </rule>
+
+    <rule ref="rulesets/java/naming.xml/LongVariable">
+        <properties>
+            <property name="minimum" value="25"/>
+        </properties>
+    </rule>
   
 </ruleset>


### PR DESCRIPTION
Just a unit test for https://jira.codehaus.org/browse/MPMD-171
Couldn't reproduce it anymore. The issue was probably fixed with PMD 5.0.3/5.0.4.
The bug report is for m-pmd-p 3.0.1, which uses PMD 5.0.2.

Related bugs are: https://sourceforge.net/p/pmd/bugs/1074/ (rule priority doesn't work on group definitions) and https://sourceforge.net/p/pmd/bugs/1089/ (When changing priority in a custom ruleset, violations reported twice)
