### PR TITLE
Support for purging output directory before unpacking. If a new version ...

### DIFF
--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugin/dependency/AbstractDependencyMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugin/dependency/AbstractDependencyMojo.java
@@ -202,6 +202,30 @@ public abstract class AbstractDependencyMojo
     }
 
     /**
+     * Purges a folder.
+     *
+     * @param location a {@link File} object representing the folder to be purged.
+     * @throws MojoExecutionException if the input <code>location</code> is not a folder or an error occurred
+     * during the purge operation.
+     */
+    protected void purge(File location) throws MojoExecutionException {
+        if (!location.isDirectory()) {
+            throw new MojoExecutionException("Purge cannot be performed over a file.");
+        }
+
+        try {
+            if (getLog().isInfoEnabled()) {
+                getLog().info("Purging folder " + location);
+            }
+
+            FileUtils.cleanDirectory(location);
+        } catch (IOException e) {
+            throw new MojoExecutionException(
+                    String.format("Error occurred while purging directory %s.", location.getAbsolutePath()));
+        }
+    }
+
+    /**
      * Does the actual copy of the file and logging.
      *
      * @param artifact represents the file to copy.

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugin/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugin/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -63,6 +63,12 @@ public abstract class AbstractFromConfigurationMojo
     private File outputDirectory;
 
     /**
+     * Indicates if the output directory should be purged before writing to it for the first time.
+     */
+    @Parameter( property = "purgeOutputDirectory", defaultValue = "false" )
+    private boolean purgeOutputDirectory;
+
+    /**
      * Overwrite release artifacts
      *
      * @since 1.0
@@ -160,6 +166,11 @@ public abstract class AbstractFromConfigurationMojo
             {
                 artifactItem.setOutputDirectory( this.outputDirectory );
             }
+
+            if (artifactItem.shouldPurgeOutputDirectory() == null) {
+                artifactItem.setPurgeOutputDirectory(purgeOutputDirectory);
+            }
+
             artifactItem.getOutputDirectory().mkdirs();
 
             // make sure we have a version.
@@ -466,6 +477,22 @@ public abstract class AbstractFromConfigurationMojo
     public void setOutputDirectory( File theOutputDirectory )
     {
         this.outputDirectory = theOutputDirectory;
+    }
+
+    /**
+     * Returns if the output directory should be purged before writing to it.
+     */
+    public boolean shouldPurgeOutputDirectory() {
+        return purgeOutputDirectory;
+    }
+
+    /**
+     * Sets if the output directory should be purged before writing to it.
+     *
+     * @param purgeOutputDirectory true to purge before writing
+     */
+    public void setPurgeOutputDirectory(boolean purgeOutputDirectory) {
+        this.purgeOutputDirectory = purgeOutputDirectory;
     }
 
     /**

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugin/dependency/fromConfiguration/ArtifactItem.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugin/dependency/fromConfiguration/ArtifactItem.java
@@ -88,6 +88,11 @@ public class ArtifactItem
     private File outputDirectory;
 
     /**
+     * A flag indicating if a the output directory for the artifact should be purged before writing to it.
+     */
+    private Boolean purgeOutputDirectory;
+
+    /**
      * Provides ability to change destination file name
      *
      * @parameter
@@ -276,6 +281,20 @@ public class ArtifactItem
     public void setOutputDirectory( File outputDirectory )
     {
         this.outputDirectory = outputDirectory;
+    }
+
+    /**
+     * Returns if the output directory for the artifact should be purged before writing to it.
+     */
+    public Boolean shouldPurgeOutputDirectory() {
+        return purgeOutputDirectory;
+    }
+
+    /**
+     * Sets if the output directory for the artifact should be purged before writing to it.
+     */
+    public void setPurgeOutputDirectory(boolean purgeOutputDirectory) {
+        this.purgeOutputDirectory = purgeOutputDirectory;
     }
 
     /**


### PR DESCRIPTION
...of the artifact is available and part of the contents is deleted in this new version, it should be deleted after unpacking to avoid undesired side effects. E.g. if we deploy large test data (let's say > 1 GB ) we would like to unpack it only if there is a change in the data but anything deleted from the previous version should be removed too. purgingOutputDirectory provides this capability. The consumer should be careful to configure purging in a non-conflicting way which can end up with deleting data that won't be unpacked.(If two artifacts have the same output folder and one of them needs processing and purges the output folder, then the other one should be unpacked even if it is not updated)
