### PR TITLE
Avoid overwrite of the destination file if the produced contents is the same

### DIFF
--- a/maven-remote-resources-plugin/pom.xml
+++ b/maven-remote-resources-plugin/pom.xml
@@ -146,6 +146,11 @@ under the License.
 
     <!-- other -->
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity</artifactId>
       <version>1.7</version>


### PR DESCRIPTION
maven-remote-resource-plugin is used in Apache pom to add DEPENDENCIES, and the resulting file is overwritten on each build.
It leads to jar being rebuild, etc leading to longer compilation times.
