### PR TITLE
Update error-prone integration test

### DIFF
--- a/maven-compiler-plugin/src/it/error-prone-compiler/src/main/java/MyClass.java
+++ b/maven-compiler-plugin/src/it/error-prone-compiler/src/main/java/MyClass.java
@@ -21,8 +21,8 @@ public class MyClass
 {
 
     public static void main(String[] args) {
-        if (args.length < 1);
-        throw new IllegalArgumentException("Missing required argument");
+        // error: dead exception
+        new Exception();
     }
 
 }

--- a/maven-compiler-plugin/src/it/error-prone-compiler/verify.groovy
+++ b/maven-compiler-plugin/src/it/error-prone-compiler/verify.groovy
@@ -21,4 +21,4 @@ assert logFile.exists()
 content = logFile.text
 
 assert content.contains( 'Compilation failure' )
-assert content.contains( '[EmptyIf] Empty statement after if' )
+assert content.contains( '[DeadException] Exception created but not thrown' )


### PR DESCRIPTION
EmptyIf is no longer one of the default errors, use DeadException
instead.
