### PR TITLE
MPIR-268: Mirror Dependency Information to Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 out/
 .DS_Store
 .java-version
+.factorypath


### PR DESCRIPTION
Add 'Gradle' to Grails as they are the same matching maven central.
Move SBT up in order and add 'Scala' to match maven central.
