### PR TITLE
MECLIPSE-738: Fix constructing a LinkedResource with a locationURI

### DIFF
--- a/maven-eclipse-plugin/pom.xml
+++ b/maven-eclipse-plugin/pom.xml
@@ -220,7 +220,7 @@ under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-eclipse-plugin/src/main/java/org/apache/maven/plugin/eclipse/LinkedResource.java
+++ b/maven-eclipse-plugin/src/main/java/org/apache/maven/plugin/eclipse/LinkedResource.java
@@ -128,7 +128,15 @@ public class LinkedResource
             throw new IllegalArgumentException( "Both location and locationURI nodes are set." );
         }
 
-        location = locationNode.getValue();
+        if (locationNode != null)
+        {
+            location = locationNode.getValue();
+        }
+
+        if (locationURINode != null)
+        {
+            locationURI = locationURINode.getValue();
+        }
     }
 
     public void print( XMLWriter writer )

--- a/maven-eclipse-plugin/src/test/java/org/apache/maven/plugin/eclipse/LinkedResourceTest.java
+++ b/maven-eclipse-plugin/src/test/java/org/apache/maven/plugin/eclipse/LinkedResourceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.maven.plugin.eclipse;
+
+import static org.junit.Assert.assertEquals;
+
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
+
+public class LinkedResourceTest
+{
+    @Test
+    public void nodeWithOnlyLocationIsAccepted()
+    {
+        Xpp3Dom node = new Xpp3Dom("test");
+        node.addChild(new Xpp3Dom("name"));
+        node.addChild(new Xpp3Dom("type"));
+
+        Xpp3Dom location = new Xpp3Dom("location");
+        location.setValue("the-location");
+
+        node.addChild(location);
+
+        LinkedResource lr = new LinkedResource(node);
+        assertEquals("the-location", lr.getLocation());
+    }
+
+    @Test
+    public void nodeWithOnlyLocationUriIsAccepted()
+    {
+        Xpp3Dom node = new Xpp3Dom("test");
+        node.addChild(new Xpp3Dom("name"));
+        node.addChild(new Xpp3Dom("type"));
+
+        Xpp3Dom location = new Xpp3Dom("locationURI");
+        location.setValue("the-location-uri");
+
+        node.addChild(location);
+
+        LinkedResource lr = new LinkedResource(node);
+        assertEquals("the-location-uri", lr.getLocationURI());
+    }
+}


### PR DESCRIPTION
Allow that either, but not both, and not neither, of the location
properties could be set. Include tests, and upgrade JUnit to allow
use of annotations.
