### PR TITLE
[MDEP-490] Add option to ignore exclusion errors

### DIFF
--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDepMgt.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDepMgt.java
@@ -187,8 +187,8 @@ public class AnalyzeDepMgt
             for ( Artifact exclusion : exclusionErrors )
             {
                 getLog().info( StringUtils.stripEnd( getArtifactManagementKey( exclusion ), ":" )
-                    + " was excluded in DepMgt, but version " + exclusion.getVersion()
-                    + " has been found in the dependency tree." );
+                                   + " was excluded in DepMgt, but version " + exclusion.getVersion()
+                                   + " has been found in the dependency tree." );
                 foundError = true;
             }
 

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDepMgt.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDepMgt.java
@@ -78,6 +78,12 @@ public class AnalyzeDepMgt
     private boolean ignoreDirect = true;
 
     /**
+     * Ignore excluded dependencies that appear in the dependency tree.
+     */
+    @Parameter( property = "mdep.analyze.ignore.exclusion.errors", defaultValue = "false" )
+    private boolean ignoreExclusionErrors = false;
+
+    /**
      * Skip plugin execution completely.
      *
      * @since 2.7
@@ -162,14 +168,17 @@ public class AnalyzeDepMgt
                 allDependencyArtifacts.removeAll( directDependencies );
             }
 
-            // log exclusion errors
-            List<Artifact> exclusionErrors = getExclusionErrors( exclusions, allDependencyArtifacts );
-            for ( Artifact exclusion : exclusionErrors )
+            if ( !this.ignoreExclusionErrors )
             {
-                getLog().info( StringUtils.stripEnd( getArtifactManagementKey( exclusion ), ":" )
-                                   + " was excluded in DepMgt, but version " + exclusion.getVersion()
-                                   + " has been found in the dependency tree." );
-                foundError = true;
+                // log exclusion errors
+                List<Artifact> exclusionErrors = getExclusionErrors( exclusions, allDependencyArtifacts );
+                for ( Artifact exclusion : exclusionErrors )
+                {
+                    getLog().info( StringUtils.stripEnd( getArtifactManagementKey( exclusion ), ":" )
+                        + " was excluded in DepMgt, but version " + exclusion.getVersion()
+                        + " has been found in the dependency tree." );
+                    foundError = true;
+                }
             }
 
             // find and log version mismatches
@@ -359,5 +368,21 @@ public class AnalyzeDepMgt
     public void setIgnoreDirect( boolean theIgnoreDirect )
     {
         this.ignoreDirect = theIgnoreDirect;
+    }
+
+    /**
+     * @return the ignoreExclusionErrors
+     */
+    protected final boolean isIgnoreExclusionErrors()
+    {
+        return this.ignoreExclusionErrors;
+    }
+
+    /**
+     * @param theIgnoreExclusionErrors the ignoreExclusionErrors to set
+     */
+    public void setIgnoreExclusionErrors( boolean theIgnoreExclusionErrors )
+    {
+        this.ignoreExclusionErrors = theIgnoreExclusionErrors;
     }
 }

--- a/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDepMgt.java
+++ b/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDepMgt.java
@@ -22,7 +22,10 @@ package org.apache.maven.plugins.dependency.analyze;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -175,6 +178,18 @@ public class TestAnalyzeDepMgt
         assertEquals( 1,map.size() );
         assertTrue( map.containsKey( mojo.getExclusionKey( ex ) ) );
         assertSame( ex, map.get( mojo.getExclusionKey( ex ) ) );
+
+        mojo.setIgnoredExclusions( Collections.singleton( mojo.getExclusionKey( ex ) ) );
+        assertEquals( 0, mojo.addExclusions( list ).size() );
+
+        mojo.setIgnoredExclusions( Collections.singleton( ex.getGroupId() + ":*" ) );
+        assertEquals( 0, mojo.addExclusions( list ).size() );
+
+        mojo.setIgnoredExclusions( Collections.singleton( "*:" + ex.getArtifactId() ) );
+        assertEquals( 0, mojo.addExclusions( list ).size() );
+
+        mojo.setIgnoredExclusions( Collections.singleton( "*:*" ) );
+        assertEquals( 0, mojo.addExclusions( list ).size() );
     }
 
     public void testGetExclusionErrors()
@@ -267,7 +282,7 @@ public class TestAnalyzeDepMgt
         {
             DependencyProjectStub project = (DependencyProjectStub) mojo.getProject();
             project.setDependencyManagement( depMgtMatchingVersion );
-            // test without ignore exclusion errors
+            // test without ignoring the exclusion error
             mojo.setFailBuild( true );
             mojo.setIgnoreDirect( false );
             mojo.execute();
@@ -282,10 +297,10 @@ public class TestAnalyzeDepMgt
         {
             DependencyProjectStub project = (DependencyProjectStub) mojo.getProject();
             project.setDependencyManagement( depMgtMatchingVersion );
-            // test with ignore exclusion errors
+            // test with the exclusion error ignored
             mojo.setFailBuild( true );
             mojo.setIgnoreDirect( false );
-            mojo.setIgnoreExclusionErrors(true);
+            mojo.setIgnoredExclusions( Collections.singleton(mojo.getExclusionKey( ex )) );
             mojo.execute();
         }
         catch ( Exception e )

--- a/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDepMgt.java
+++ b/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDepMgt.java
@@ -300,7 +300,7 @@ public class TestAnalyzeDepMgt
             // test with the exclusion error ignored
             mojo.setFailBuild( true );
             mojo.setIgnoreDirect( false );
-            mojo.setIgnoredExclusions( Collections.singleton(mojo.getExclusionKey( ex )) );
+            mojo.setIgnoredExclusions( Collections.singleton( mojo.getExclusionKey( ex ) ) );
             mojo.execute();
         }
         catch ( Exception e )

--- a/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDepMgt.java
+++ b/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDepMgt.java
@@ -47,12 +47,14 @@ public class TestAnalyzeDepMgt
     DependencyArtifactStubFactory stubFactory;
 
     Dependency exclusion;
+    Dependency exclusionMatchingVersion;
 
     Exclusion ex;
 
     Artifact exclusionArtifact;
 
     DependencyManagement depMgt;
+    DependencyManagement depMgtMatchingVersion;
     DependencyManagement depMgtNoExclusions;
     protected void setUp()
         throws Exception
@@ -87,6 +89,20 @@ public class TestAnalyzeDepMgt
         depMgt = new DependencyManagement();
         depMgt.setDependencies( list );
 
+        exclusionMatchingVersion = new Dependency();
+        exclusionMatchingVersion.setArtifactId( exclusionArtifact.getArtifactId() );
+        exclusionMatchingVersion.setGroupId( exclusionArtifact.getGroupId() );
+        exclusionMatchingVersion.setType( exclusionArtifact.getType() );
+        exclusionMatchingVersion.setClassifier( "" );
+        exclusionMatchingVersion.setVersion( exclusionArtifact.getVersion() );
+
+        exclusionMatchingVersion.addExclusion( ex );
+
+        list = new ArrayList<Dependency>();
+        list.add( exclusionMatchingVersion );
+
+        depMgtMatchingVersion = new DependencyManagement();
+        depMgtMatchingVersion.setDependencies( list );
 
         project.setArtifacts( allArtifacts );
         project.setDependencyArtifacts( directArtifacts );
@@ -239,6 +255,37 @@ public class TestAnalyzeDepMgt
             // test with exclusion
             mojo.setFailBuild( true );
             mojo.setIgnoreDirect( true );
+            mojo.execute();
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            fail( "Caught Unexpected Exception:" + e.getLocalizedMessage() );
+        }
+
+        try
+        {
+            DependencyProjectStub project = (DependencyProjectStub) mojo.getProject();
+            project.setDependencyManagement( depMgtMatchingVersion );
+            // test without ignore exclusion errors
+            mojo.setFailBuild( true );
+            mojo.setIgnoreDirect( false );
+            mojo.execute();
+            fail( "Expected exception to fail the build." );
+        }
+        catch ( Exception e )
+        {
+            System.out.println("Caught Expected Exception:" + e.getLocalizedMessage());
+        }
+
+        try
+        {
+            DependencyProjectStub project = (DependencyProjectStub) mojo.getProject();
+            project.setDependencyManagement( depMgtMatchingVersion );
+            // test with ignore exclusion errors
+            mojo.setFailBuild( true );
+            mojo.setIgnoreDirect( false );
+            mojo.setIgnoreExclusionErrors(true);
             mojo.execute();
         }
         catch ( Exception e )


### PR DESCRIPTION
I would like to run the analyze-dep-mgt goal with failBuild=true, but need to be able to ignore exclusion errors in order to do so. A common example I've run into is many projects that accidentally depend on junit at compile scope instead of test scope. When I encounter a project like this, I add an exclusion on junit. But I have junit in my dependency tree (at scope test) which causes my build to fail with a message such as:

```
[INFO] junit:junit:jar was excluded in DepMgt, but version 4.11 has been found in the dependency tree.
```

This PR makes it possible to ignore these exclusion errors (if users want to enforce banned dependencies the enforcer plugin has more robust support this) while still failing the build if there are version mismatches
