### PR TITLE
[MCOMPILER-243] Place compilerArgs inside configuration.

### DIFF
--- a/maven-compiler-plugin/src/site/apt/examples/pass-compiler-arguments.apt.vm
+++ b/maven-compiler-plugin/src/site/apt/examples/pass-compiler-arguments.apt.vm
@@ -44,10 +44,12 @@ Pass Compiler Arguments
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${project.version}</version>
-        <compilerArgs>
+        <configuration>
+          <compilerArgs>
             <arg>-verbose</arg>
             <arg>-Xlint:all,-options,-path</arg>
           </compilerArgs>
+        </configuration>
       </plugin>
     </plugins>
     [...]


### PR DESCRIPTION
Documentation for compilerArgs is incorrect.

See: http://maven.apache.org/plugins/maven-compiler-plugin/examples/pass-compiler-arguments.html

The compilerArgs tag should be inside the configuration tags.

This contribution is my original work and I license the work to the project under the project's open source license.
