### PR TITLE
Suggest using verify phase for Checkstyle

### DIFF
--- a/maven-checkstyle-plugin/src/site/apt/usage.apt.vm
+++ b/maven-checkstyle-plugin/src/site/apt/usage.apt.vm
@@ -94,8 +94,8 @@ mvn checkstyle:checkstyle
    <version>${project.version}</version>
    <executions>
      <execution>
-       <id>validate</id>
-       <phase>validate</phase>
+       <id>verify</id>
+       <phase>verify</phase>
        <configuration>
          <configLocation>checkstyle.xml</configLocation>
          <encoding>UTF-8</encoding>


### PR DESCRIPTION
The Maven lifecycle[1] reference suggests using validate to:

> validate the project is correct and all necessary information is available.

and verify to:

> run any checks to verify the package is valid and meets quality criteria.

The latter better matches Checkstyle's functionality and matches
similar tools like FindBugs[2].

[1] https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference
[2] http://gleclaire.github.io/findbugs-maven-plugin/check-mojo.html
