### PR TITLE
MSOURCES-81 add jar maven descriptor if configured

### DIFF
--- a/maven-source-plugin/src/main/java/org/apache/maven/plugin/source/AbstractSourceJarMojo.java
+++ b/maven-source-plugin/src/main/java/org/apache/maven/plugin/source/AbstractSourceJarMojo.java
@@ -101,7 +101,7 @@ public abstract class AbstractSourceJarMojo
      * @since 2.1
      */
     @Parameter
-    private MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
+    private MavenArchiveConfiguration archive = new SourceArchiveConfiguration();
 
     /**
      * Path to the default MANIFEST file to use. It will be used if <code>useDefaultManifestFile</code> is set to
@@ -287,9 +287,7 @@ public abstract class AbstractSourceJarMojo
 
             try
             {
-                archiver.setOutputFile( outputFile );
-
-                archive.setAddMavenDescriptor( false );
+                archiver.setOutputFile(outputFile);
                 archive.setForced( forceCreation );
 
                 archiver.createArchive( session, project, archive );

--- a/maven-source-plugin/src/main/java/org/apache/maven/plugin/source/SourceArchiveConfiguration.java
+++ b/maven-source-plugin/src/main/java/org/apache/maven/plugin/source/SourceArchiveConfiguration.java
@@ -1,0 +1,36 @@
+package org.apache.maven.plugin.source;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.archiver.MavenArchiveConfiguration;
+
+/**
+ * For backwards compatibility, a custom archiver configuration that defaults to not including the Maven descriptor.
+ *
+ * @see <a href="https://issues.apache.org/browse/MSOURCES-81">MSOURCES-81</a>
+ * @since 2.4
+ */
+public class SourceArchiveConfiguration
+    extends MavenArchiveConfiguration
+{
+  public SourceArchiveConfiguration() {
+    setAddMavenDescriptor(false);
+  }
+}

--- a/maven-source-plugin/src/test/java/org/apache/maven/plugin/source/SourceJarMojoTest.java
+++ b/maven-source-plugin/src/test/java/org/apache/maven/plugin/source/SourceJarMojoTest.java
@@ -56,17 +56,17 @@ public class SourceJarMojoTest
         executeMojo( "project-005", "sources" );
         // Now make sure that no archive got created
         final File expectedFile = getTestTargetDir( "project-005" );
-        assertFalse( "Source archive should not have been created[" + expectedFile.getAbsolutePath() + "]",
-                     expectedFile.exists() );
+        assertFalse("Source archive should not have been created[" + expectedFile.getAbsolutePath() + "]",
+                expectedFile.exists());
     }
 
     public void testIncludes()
         throws Exception
     {
-        doTestProjectWithSourceArchive( "project-007", new String[]{ "templates/configuration-template.properties",
-            "foo/project007/App.java", "templates/", "foo/project007/", "foo/", "META-INF/MANIFEST.MF", "META-INF/"
+        doTestProjectWithSourceArchive("project-007", new String[]{"templates/configuration-template.properties",
+                "foo/project007/App.java", "templates/", "foo/project007/", "foo/", "META-INF/MANIFEST.MF", "META-INF/"
 
-        }, "sources" );
+        }, "sources");
     }
 
     public void testIncludePom()
@@ -74,5 +74,20 @@ public class SourceJarMojoTest
     {
         doTestProjectWithSourceArchive( "project-009", new String[]{ "default-configuration.properties", "pom.xml",
             "foo/project009/App.java", "foo/project009/", "foo/", "META-INF/MANIFEST.MF", "META-INF/" }, "sources" );
+    }
+
+    public void testIncludeMavenDescriptorWhenExplicitlyConfigured()
+            throws Exception {
+        doTestProjectWithSourceArchive("project-010",
+                new String[]{
+                        "default-configuration.properties", "foo/project010/App.java",
+                        "foo/project010/", "foo/", "META-INF/MANIFEST.MF", "META-INF/",
+                        "META-INF/maven/", "META-INF/maven/source/",
+                        "META-INF/maven/source/maven-source-plugin-test-project-010/",
+                        "META-INF/maven/source/maven-source-plugin-test-project-010/pom.xml",
+                        "META-INF/maven/source/maven-source-plugin-test-project-010/pom" +
+                                ".properties"
+                },
+                "sources");
     }
 }

--- a/maven-source-plugin/src/test/java/org/apache/maven/plugin/source/TestSourceJarMojoTest.java
+++ b/maven-source-plugin/src/test/java/org/apache/maven/plugin/source/TestSourceJarMojoTest.java
@@ -59,8 +59,23 @@ public class TestSourceJarMojoTest
 
         // Now make sure that no archive got created
         final File expectedFile = getTestTargetDir( "project-005" );
-        assertFalse( "Test source archive should not have been created[" + expectedFile.getAbsolutePath() + "]",
-                     expectedFile.exists() );
+        assertFalse("Test source archive should not have been created[" + expectedFile.getAbsolutePath() + "]",
+                expectedFile.exists());
+    }
+
+    public void testIncludeMavenDescriptorWhenExplicitlyConfigured()
+            throws Exception {
+        doTestProjectWithSourceArchive("project-010",
+                new String[]{
+                        "default-configuration.properties", "foo/project010/App.java",
+                        "foo/project010/", "foo/", "META-INF/MANIFEST.MF", "META-INF/",
+                        "META-INF/maven/", "META-INF/maven/source/",
+                        "META-INF/maven/source/maven-source-plugin-test-project-010/",
+                        "META-INF/maven/source/maven-source-plugin-test-project-010/pom.xml",
+                        "META-INF/maven/source/maven-source-plugin-test-project-010/pom" +
+                                ".properties"
+                },
+                "test-sources");
     }
 
 }

--- a/maven-source-plugin/src/test/java/org/apache/maven/plugin/source/stubs/Project010Stub.java
+++ b/maven-source-plugin/src/test/java/org/apache/maven/plugin/source/stubs/Project010Stub.java
@@ -1,0 +1,122 @@
+package org.apache.maven.plugin.source.stubs;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.codehaus.plexus.util.ReaderFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Project010Stub
+    extends MavenProjectStub
+{
+    private Build build;
+
+    private List resources;
+
+    private List testResources;
+
+    public Project010Stub()
+    {
+        MavenXpp3Reader pomReader = new MavenXpp3Reader();
+        Model model;
+
+        try
+        {
+            model = pomReader.read(
+                ReaderFactory.newXmlReader( new File( getBasedir(), "target/test-classes/unit/project-010/pom.xml" ) ) );
+            setModel( model );
+
+            setFile(new File( getBasedir(), "target/test-classes/unit/project-010/pom.xml" ));
+
+            setGroupId(model.getGroupId());
+            setArtifactId(model.getArtifactId());
+            setVersion(model.getVersion());
+            setName(model.getName());
+            setUrl(model.getUrl());
+            setPackaging(model.getPackaging());
+
+            Build build = new Build();
+            build.setFinalName( getArtifactId() + "-" + getVersion() );
+            build.setDirectory(getBasedir() + "/target/test/unit/project-010/target");
+
+            setBuild(build);
+
+            String basedir = getBasedir().getAbsolutePath();
+            List compileSourceRoots = new ArrayList();
+            compileSourceRoots.add( basedir + "/target/test-classes/unit/project-010/src/main/java" );
+            setCompileSourceRoots(compileSourceRoots);
+
+            List testCompileSourceRoots = new ArrayList();
+            testCompileSourceRoots.add(basedir + "/target/test-classes/unit/project-010/src/test/java");
+            setTestCompileSourceRoots(testCompileSourceRoots);
+
+            setResources(model.getBuild().getResources());
+            setTestResources(model.getBuild().getTestResources());
+
+            SourcePluginArtifactStub artifact =
+                new SourcePluginArtifactStub( getGroupId(), getArtifactId(), getVersion(), getPackaging(), null );
+            artifact.setArtifactHandler(new DefaultArtifactHandlerStub());
+            artifact.setType("jar");
+            artifact.setBaseVersion("1.0-SNAPSHOT");
+            setArtifact( artifact );
+
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+        }
+    }
+
+    public Build getBuild()
+    {
+        return build;
+    }
+
+    public void setBuild( Build build )
+    {
+        this.build = build;
+    }
+
+    public List getResources()
+    {
+        return resources;
+    }
+
+    public void setResources( List resources )
+    {
+        this.resources = resources;
+    }
+
+    public List getTestResources()
+    {
+        return testResources;
+    }
+
+    public void setTestResources( List testResources )
+    {
+        this.testResources = testResources;
+    }
+}

--- a/maven-source-plugin/src/test/resources/unit/project-010/pom.xml
+++ b/maven-source-plugin/src/test/resources/unit/project-010/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>source</groupId>
+  <artifactId>maven-source-plugin-test-project-010</artifactId>
+  <version>99.0</version>
+  <name>Maven</name>
+  <packaging>jar</packaging>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>target/test-classes/unit/project-010/src/main/resources</directory>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>target/test-classes/unit/project-010/src/test/resources</directory>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugin.source.stubs.Project010Stub"/>
+          <outputDirectory>${basedir}/target/test/unit/project-010/target</outputDirectory>
+          <finalName>maven-source-plugin-test-project-010-99.0</finalName>
+          <reactorProjects/>
+          <archive>
+            <addMavenDescriptor>true</addMavenDescriptor>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-source-plugin/src/test/resources/unit/project-010/src/main/java/foo/project010/App.java
+++ b/maven-source-plugin/src/test/resources/unit/project-010/src/main/java/foo/project010/App.java
@@ -1,0 +1,32 @@
+package foo.project010;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class App
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/maven-source-plugin/src/test/resources/unit/project-010/src/main/resources/.cvsignore
+++ b/maven-source-plugin/src/test/resources/unit/project-010/src/main/resources/.cvsignore
@@ -1,0 +1,1 @@
+## we don't care about this one since it's handled by default excludes (well at least it should).

--- a/maven-source-plugin/src/test/resources/unit/project-010/src/main/resources/default-configuration.properties
+++ b/maven-source-plugin/src/test/resources/unit/project-010/src/main/resources/default-configuration.properties
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/maven-source-plugin/src/test/resources/unit/project-010/src/test/java/foo/project010/AppTest.java
+++ b/maven-source-plugin/src/test/resources/unit/project-010/src/test/java/foo/project010/AppTest.java
@@ -1,0 +1,57 @@
+package foo.project010;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}

--- a/maven-source-plugin/src/test/resources/unit/project-010/src/test/resources/.cvsignore
+++ b/maven-source-plugin/src/test/resources/unit/project-010/src/test/resources/.cvsignore
@@ -1,0 +1,1 @@
+## we don't care about this one since it's handled by default excludes (well at least it should).

--- a/maven-source-plugin/src/test/resources/unit/project-010/src/test/resources/test-default-configuration.properties
+++ b/maven-source-plugin/src/test/resources/unit/project-010/src/test/resources/test-default-configuration.properties
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
Note: maven-archiver dependency version was upgraded to take advantage of MavenProject.clone(), which avoids having the new unit test from creating a maven-archiver directory in the maven-source-plugin basedir because the MavenProject() constructor used in 2.5 does not copy the build element.
