### PR TITLE
Add new option "failOnWarning".

### DIFF
--- a/maven-compiler-plugin/src/it/fail-on-warning/invoker.properties
+++ b/maven-compiler-plugin/src/it/fail-on-warning/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean compile
+invoker.buildResult = failure
+invoker.java.version = 1.6+

--- a/maven-compiler-plugin/src/it/fail-on-warning/pom.xml
+++ b/maven-compiler-plugin/src/it/fail-on-warning/pom.xml
@@ -1,0 +1,66 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.compiler.it</groupId>
+  <artifactId>fail-on-warning</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Werror warnings build</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.14</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <verbose>true</verbose>
+          <debug>true</debug>
+          <optimize>true</optimize>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <failOnWarning>true</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all,-options,-path</arg>
+          </compilerArgs>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-compiler-plugin/src/it/fail-on-warning/src/main/java/org/maven/test/Main.java
+++ b/maven-compiler-plugin/src/it/fail-on-warning/src/main/java/org/maven/test/Main.java
@@ -1,0 +1,35 @@
+package org.maven.test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+public class Main {
+    /**
+     * @param args
+     */
+    public static void main(String[] args) {
+        List blah = new ArrayList();
+        blah.add("hello");
+    }
+}

--- a/maven-compiler-plugin/src/it/fail-on-warning/verify.groovy
+++ b/maven-compiler-plugin/src/it/fail-on-warning/verify.groovy
@@ -1,0 +1,27 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def logFile = new File( basedir, 'build.log' )
+assert logFile.exists()
+content = logFile.text
+
+assert content.contains( 'Compilation failure' )
+assert !content.contains( 'invalid flag' )
+assert content.contains( 'unchecked call to add(E) as a member of the raw type ' ) // List or java.util.List
+

--- a/maven-compiler-plugin/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/maven-compiler-plugin/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -87,6 +87,14 @@ public abstract class AbstractCompilerMojo
     private boolean failOnError = true;
 
     /**
+     * Indicates whether the build will continue even if there are compilation warnings.
+     *
+     * @since 3.4
+     */
+    @Parameter( property = "maven.compiler.failOnWarning", defaultValue = "false" )
+    private boolean failOnWarning = false;
+
+    /**
      * Set to <code>true</code> to include debugging information in the compiled class files.
      */
     @Parameter( property = "maven.compiler.debug", defaultValue = "true" )
@@ -235,7 +243,7 @@ public abstract class AbstractCompilerMojo
      * </pre>
      *
      * @since 2.0.1
-     * @deprecated use {@link #compilerArgs} instead. 
+     * @deprecated use {@link #compilerArgs} instead.
      */
     @Parameter
     @Deprecated
@@ -257,7 +265,7 @@ public abstract class AbstractCompilerMojo
      */
     @Parameter
     protected List<String> compilerArgs;
-    
+
     /**
      * <p>
      * Sets the unformatted single argument string to be passed to the compiler if {@link #fork} is set to
@@ -550,7 +558,7 @@ public abstract class AbstractCompilerMojo
         String effectiveCompilerArgument = getCompilerArgument();
 
         if ( ( effectiveCompilerArguments != null ) || ( effectiveCompilerArgument != null )
-                        || ( compilerArgs != null ) )
+                        || ( compilerArgs != null ) || failOnWarning )
         {
             LinkedHashMap<String, String> cplrArgsCopy = new LinkedHashMap<String, String>();
             if ( effectiveCompilerArguments != null )
@@ -584,6 +592,10 @@ public abstract class AbstractCompilerMojo
                 {
                     cplrArgsCopy.put( arg, null );
                 }
+            }
+            if ( failOnWarning )
+            {
+                cplrArgsCopy.put( "-Werror", null );
             }
             compilerConfiguration.setCustomCompilerArguments( cplrArgsCopy );
         }

--- a/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
+++ b/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
@@ -273,6 +273,25 @@ public class CompilerMojoTestCase
         }
     }
 
+    public void testCompileFailOnWarning()
+                    throws Exception
+    {
+        CompilerMojo compileMojo = getCompilerMojo( "target/test-classes/unit/compiler-failonwarning-test/plugin-config.xml" );
+
+        setVariableValueToObject( compileMojo, "compilerManager", new CompilerManagerStub( true, true ) );
+
+        try
+        {
+            compileMojo.execute();
+
+            fail( "Should throw an exception" );
+        }
+        catch ( CompilationFailureException e )
+        {
+            //expected
+        }
+    }
+
     public void testCompileFailOnError()
         throws Exception
     {
@@ -338,7 +357,7 @@ public class CompilerMojoTestCase
             junitURI = junitURI.substring( "jar:".length(), junitURI.indexOf( '!' ) );
             testClasspathList.add( new File( URI.create( junitURI ) ).getAbsolutePath() );
         }
-        
+
         testClasspathList.add( compilerMojo.getOutputDirectory().getPath() );
         setVariableValueToObject( mojo, "classpathElements", testClasspathList );
 

--- a/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerManagerStub.java
+++ b/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerManagerStub.java
@@ -29,20 +29,27 @@ public class CompilerManagerStub
     implements CompilerManager
 {
     private boolean shouldFail;
+    private boolean shouldWarn;
 
     public CompilerManagerStub()
     {
-        this( false );
+        this( false, false );
     }
 
     public CompilerManagerStub( boolean shouldFail )
     {
+        this( shouldFail, false );
+    }
+
+    public CompilerManagerStub( boolean shouldFail, boolean shouldWarn )
+    {
         this.shouldFail = shouldFail;
+        this.shouldWarn = shouldWarn;
     }
 
     public org.codehaus.plexus.compiler.Compiler getCompiler( String compilerId )
         throws NoSuchCompilerException
     {
-        return new CompilerStub( shouldFail );
+        return new CompilerStub( shouldFail, shouldWarn );
     }
 }

--- a/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerStub.java
+++ b/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerStub.java
@@ -38,15 +38,22 @@ public class CompilerStub
     implements org.codehaus.plexus.compiler.Compiler
 {
     private boolean shouldFail;
+    private boolean shouldWarn;
 
     public CompilerStub()
     {
-        this( false );
+        this( false, false );
     }
 
     public CompilerStub( boolean shouldFail )
     {
+        this( shouldFail, false );
+    }
+
+    public CompilerStub( boolean shouldFail, boolean shouldWarn )
+    {
         this.shouldFail = shouldFail;
+        this.shouldWarn = shouldWarn;
     }
 
     public CompilerOutputStyle getCompilerOutputStyle()
@@ -120,7 +127,7 @@ public class CompilerStub
         {
             throw new CompilerException( "An exception occurred while creating output file", e );
         }
-        
+
         return new CompilerResult( !shouldFail,
             Collections.singletonList( new CompilerMessage( "message 1", CompilerMessage.Kind.OTHER ) ) );
     }
@@ -128,6 +135,13 @@ public class CompilerStub
     public String[] createCommandLine( CompilerConfiguration compilerConfiguration )
         throws CompilerException
     {
+        if ( shouldWarn )
+        {
+            if ( ! compilerConfiguration.getCustomCompilerArguments().containsKey("-Werror") )
+            {
+                throw new CompilerException( "Compiler should error on warnings but no Werror flag found" );
+            }
+        }
         return new String[0];
     }
 }

--- a/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/plugin-config.xml
+++ b/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/plugin-config.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>true</failOnWarning>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/target/test-classes/unit/compiler-failonwarning-test/src/main/java</compileSourceRoot>
+          </compileSourceRoots>
+          <compilerId>javac</compilerId>
+          <debug>true</debug>
+          <outputDirectory>${basedir}/target/test/unit/compiler-failonwarning-test/target/classes</outputDirectory>
+          <buildDirectory>${basedir}/target/test/unit/compiler-failonwarning-test/target</buildDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/src/main/java/TestCompile0.java
+++ b/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/src/main/java/TestCompile0.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestCompile0
+{
+
+    public TestCompile0()
+    {
+        List xxx = new ArrayList();
+        System.out.println( "Woo Hoo!" );
+    }
+
+}

--- a/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/src/test/java/TestCompile0Test.java
+++ b/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/src/test/java/TestCompile0Test.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+public class TestCompile0Test
+    extends TestCase
+{
+    public void testCompile0Test()
+    {
+        List foo = new ArrayList();
+        TestCompile0 test = new TestCompile0();
+    }
+}


### PR DESCRIPTION
This option causes the maven-compiler-plugin to treat warnings as errors
and fail accordingly.

Simply adds "-Werror" to the compiler command line. It may be nice to
add this to the plexus-compiler-api proper but as the sonatype repo only
has tags to 2.4 and the current plugin references 2.6 (and I have no
idea where that comes from), I went the easy route. Happy to refactor
it if wanted.
