### PR TITLE
Compute the set of clazzes of a ClazzpathUnit only once

### DIFF
--- a/maven-shade-plugin/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/maven-shade-plugin/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -173,12 +173,13 @@ public class MinijarFilter
                     ClazzpathUnit depClazzpathUnit = addDependencyToClasspath( checkCp, dependency );
                     if ( depClazzpathUnit != null )
                     {
+                        Set<Clazz> clazzes = depClazzpathUnit.getClazzes();
                         Iterator<Clazz> j = removable.iterator();
                         while ( j.hasNext() )
                         {
                             Clazz clazz = j.next();
 
-                            if ( depClazzpathUnit.getClazzes().contains( clazz ) //
+                            if ( clazzes.contains( clazz ) //
                                 && simpleFilter.isSpecificallyIncluded( clazz.getName().replace( '.', '/' ) ) )
                             {
                                 log.info( clazz.getName() + " not removed because it was specifically included" );


### PR DESCRIPTION
The method `getClazzes()` in `org.vafer.jdependency.ClazzpathUnit`
actually builds a hash set and fills it up, each time it is called.
Here it was called once for each removable clazz.

Minimizing jars immediately becomes an order of magnitude faster.
