### PR TITLE
Updated to add dash for no-fork

### DIFF
--- a/maven-javadoc-plugin/src/site/apt/index.apt.vm
+++ b/maven-javadoc-plugin/src/site/apt/index.apt.vm
@@ -57,12 +57,12 @@ javadoc.exe(or .sh) @options @packages | @argfile
    * {{{./test-javadoc-mojo.html}javadoc:test-javadoc}} generates the test Javadoc files for the project. It executes
      the standard Javadoc tool and supports the parameters used by the tool.
 
-   * {{{./javadoc-nofork-mojo.html}javadoc:javadoc-nofork}} generates the Javadoc files for the project.
+   * {{{./javadoc-no-fork-mojo.html}javadoc:javadoc-no-fork}} generates the Javadoc files for the project.
      It executes the standard Javadoc tool and supports the parameters used by the tool without forking the 
      <<<generate-sources>>> phase again. Note that this goal does require generation of test sources before site generation, e.g.
      by invoking <<<mvn clean deploy site>>>.
 
-   * {{{./test-javadoc-nofork-mojo.html}javadoc:test-javadoc-nofork}} generates the test Javadoc files for the project. 
+   * {{{./test-javadoc-no-fork-mojo.html}javadoc:test-javadoc-no-fork}} generates the test Javadoc files for the project. 
      It executes the standard Javadoc tool and supports the parameters used by the tool without forking the 
      <<<generate-test-sources>>> phase again. Note that this goal does require generation of test sources before site generation,
      e.g. by invoking <<<mvn clean deploy site>>>.


### PR DESCRIPTION
Not sure if this is the right place to make the change.  Noticed on https://maven.apache.org/plugins/maven-javadoc-plugin/index.html the no-fork was listed as nofork.  
