### PR TITLE
Try to replace absolute source directory paths with linked resources

### DIFF
--- a/maven-eclipse-plugin/src/test/java/org/apache/maven/plugin/eclipse/EclipsePluginUnitTest.java
+++ b/maven-eclipse-plugin/src/test/java/org/apache/maven/plugin/eclipse/EclipsePluginUnitTest.java
@@ -26,8 +26,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.apache.maven.execution.DefaultRuntimeInformation;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
@@ -35,6 +33,8 @@ import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.ide.AbstractIdeSupportMojo;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.tools.easymock.TestFileManager;
+
+import junit.framework.TestCase;
 
 public class EclipsePluginUnitTest
     extends TestCase
@@ -100,7 +100,7 @@ public class EclipsePluginUnitTest
         field.setAccessible( true );
         field.set( mojo, sourceExcludes );
 
-        EclipseSourceDir[] result = mojo.buildDirectoryList( project, basedir, new File( "target/classes" ) );
+        EclipseSourceDir[] result = mojo.buildDirectoryList( project, basedir, new File( "target/classes" ), new ArrayList() );
 
         assertEquals( "should have added 1 resource.", 1, result.length );
 


### PR DESCRIPTION
I have a project where one of the source folders is outside the main project path. With the build-helper-maven-plugin I have included this path in the maven source folders:

``` xml
<plugin>
  <groupId>org.codehaus.mojo</groupId>
  <artifactId>build-helper-maven-plugin</artifactId>
  <executions>
    <execution>
      <phase>generate-sources</phase>
      <goals><goal>add-source</goal></goals>
      <configuration>
        <sources>
          <source>${basedir}/../shared/src/main/java</source>
        </sources>
      </configuration>
    </execution>
  </executions>
</plugin>
```

If i run the eclipse plugin with this setup it will generate the following classpath entry:

``` xml
<classpathentry kind="src" path="/Users/svenrienstra/Documents/***/git/***/shared/src/main/java" including="**/*.java"/>
```

Eclipse does not accept this classpath entry. The change in this pull request will replace the absolute path with a linked resource. In the pom file I've added a linked resource:

``` xml
<plugin>
  <groupId>org.apache.maven.plugins</groupId>
  <artifactId>maven-eclipse-plugin</artifactId>
  <version>2.10</version>
  <configuration>
    <linkedResources combine.children="append"> 
     <linkedResource>
       <name>shared</name>
       <type>2</type>
       <locationURI>${basedir}/../shared/src</locationURI> 
     </linkedResource>
   </linkedResources>
  </configuration>
</plugin>
```

The code in this pull request will search through the source paths and replace any absolute path with a linked resource if there is a matching linked resource. This will result in the following classpath entry:

``` xml
 <classpathentry kind="src" path="shared/main/java" including="**/*.java"/>
```
