### PR TITLE
MCHANGES-363: Add support for opened issues in announcement Mojo

### DIFF
--- a/maven-changes-plugin/src/main/java/org/apache/maven/plugin/announcement/AnnouncementMojo.java
+++ b/maven-changes-plugin/src/main/java/org/apache/maven/plugin/announcement/AnnouncementMojo.java
@@ -446,6 +446,12 @@ public class AnnouncementMojo
     @Parameter( defaultValue = "github" )
     private String githubAPIServerId;
 
+    /**
+     * Boolean which says if we should include open github issues in the announcement.
+     */
+    @Parameter( defaultValue = "false" )
+    private boolean includeOpenIssues;
+
     private ReleaseUtils releaseUtils = new ReleaseUtils( getLog() );
 
     private ChangesXML xml;
@@ -838,7 +844,7 @@ public class AnnouncementMojo
         try
         {
             GitHubDownloader issueDownloader =
-                new GitHubDownloader( project, githubAPIScheme, githubAPIPort, false, true );
+                new GitHubDownloader( project, githubAPIScheme, githubAPIPort, includeOpenIssues, true );
 
             issueDownloader.configureAuthentication( githubAPIServerId, settings, getLog() );
 


### PR DESCRIPTION
Generate announcement file including current opened issues.
Really handy if you want to test your announcement chain without having to actually commit your changes or close issues on github.

It is currently supported when you generate the github report but not supported when you generate the github announcement.

Closes MCHANGES-363
