### PR TITLE
Cleanning log

### DIFF
--- a/maven-assembly-plugin/src/main/java/org/apache/maven/plugins/assembly/filter/ComponentsXmlArchiverFileFilter.java
+++ b/maven-assembly-plugin/src/main/java/org/apache/maven/plugins/assembly/filter/ComponentsXmlArchiverFileFilter.java
@@ -94,12 +94,7 @@ public class ComponentsXmlArchiverFileFilter
                 final String key = role + roleHint;
                 if ( !components.containsKey( key ) )
                 {
-                    System.out.println( "Adding " + key );
                     components.put( key, component );
-                }
-                else
-                {
-                    System.out.println( "Component: " + key + " is already defined. Skipping." );
                 }
             }
         }


### PR DESCRIPTION
Removed `System.out.println` call that was cluttering the maven log.
If it was crucial or important, I'm glad to change to another solution, like a conditional or something.
What do you think?
