### PR TITLE
Java 9 fixes

### DIFF
--- a/maven-jar-plugin/pom.xml
+++ b/maven-jar-plugin/pom.xml
@@ -104,7 +104,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>3.0.1</version>
+      <version>3.0.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-javadoc-plugin/pom.xml
+++ b/maven-javadoc-plugin/pom.xml
@@ -225,7 +225,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>2.9</version>
+      <version>3.0.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
maven-jar-plugin and maven-javadoc-plugin require org.codehaus.plexus:plexus-archiver:3.0.3-SNAPSHOT

plexus-archiver has had a critical change due to Java 9 changes to the java.version property

see https://github.com/codehaus-plexus/plexus-archiver/pull/12 for more information about the fix

this fix also unblocks building both junit and testng at a minimum, plus potentially any other maven project using either of these two plugins

Linked to;
https://issues.apache.org/jira/browse/MJAR-206
https://issues.apache.org/jira/browse/MJAVADOC-443
https://github.com/junit-team/junit/issues/1233
https://github.com/cbeust/testng/issues/938
