### PR TITLE
Can unpack ZIP archives with custom encodings

### DIFF
--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
@@ -37,6 +37,7 @@ import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
+import org.codehaus.plexus.archiver.zip.AbstractZipUnArchiver;
 import org.codehaus.plexus.components.io.fileselectors.IncludeExcludeFileSelector;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReflectionUtils;
@@ -176,10 +177,10 @@ public abstract class AbstractDependencyMojo
         }
     }
 
-    protected void unpack( Artifact artifact, File location )
+    protected void unpack( Artifact artifact, File location, String encoding )
         throws MojoExecutionException
     {
-        unpack( artifact, location, null, null );
+        unpack( artifact, location, null, null, encoding );
     }
 
     /**
@@ -191,14 +192,16 @@ public abstract class AbstractDependencyMojo
      *                 **&#47;*.properties</code>
      * @param excludes Comma separated list of file patterns to exclude i.e. <code>**&#47;*.xml,
      *                 **&#47;*.properties</code>
+     * @param encoding Encoding of artifact. Set {@code null} for default encoding.
      */
-    protected void unpack( Artifact artifact, File location, String includes, String excludes )
+    protected void unpack( Artifact artifact, File location, String includes, String excludes, String encoding )
         throws MojoExecutionException
     {
-        unpack( artifact, artifact.getType(), location, includes, excludes );
+        unpack( artifact, artifact.getType(), location, includes, excludes, encoding );
     }
     
-    protected void unpack( Artifact artifact, String type, File location, String includes, String excludes )
+    protected void unpack( Artifact artifact, String type, File location, String includes, String excludes,
+        String encoding )
                     throws MojoExecutionException
     {
         File file = artifact.getFile(); 
@@ -226,6 +229,12 @@ public abstract class AbstractDependencyMojo
             {
                 unArchiver = archiverManager.getUnArchiver( file );
                 getLog().debug( "Found unArchiver by extension: " + unArchiver );
+            }
+
+            if ( encoding != null && unArchiver instanceof AbstractZipUnArchiver )
+            {
+                ( ( AbstractZipUnArchiver ) unArchiver ).setEncoding( encoding );
+                getLog().info( "Unpacks with encoding '" + encoding + "'." );
             }
 
             unArchiver.setUseJvmChmod( useJvmChmod );

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -89,7 +89,7 @@ public abstract class AbstractFromConfigurationMojo
 
     /**
      * Collection of ArtifactItems to work on. (ArtifactItem contains groupId, artifactId, version, type, classifier,
-     * outputDirectory, destFileName and overWrite.) See <a href="./usage.html">Usage</a> for details.
+     * outputDirectory, destFileName, overWrite and encoding.) See <a href="./usage.html">Usage</a> for details.
      *
      * @since 1.0
      */

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ArtifactItem.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ArtifactItem.java
@@ -95,6 +95,13 @@ public class ArtifactItem implements DependencyCoordinate
     private String overWrite;
 
     /**
+     * Encoding of artifact. Overrides default encoding.
+     *
+     * @parameter
+     */
+    private String encoding;
+
+    /**
      *
      */
     private boolean needsProcessing;
@@ -313,6 +320,22 @@ public class ArtifactItem implements DependencyCoordinate
     public void setOverWrite( String overWrite )
     {
         this.overWrite = overWrite;
+    }
+
+    /**
+     * @return Returns the encoding.
+     */
+    public String getEncoding()
+    {
+        return this.encoding;
+    }
+
+    /**
+     * @param encoding The encoding to set.
+     */
+    public void setEncoding( String encoding )
+    {
+        this.encoding = encoding;
     }
 
     /**

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
@@ -126,7 +126,7 @@ public class UnpackMojo
         MarkerHandler handler = new UnpackFileMarkerHandler( artifactItem, this.markersDirectory );
         
         unpack( artifactItem.getArtifact(), artifactItem.getType(), artifactItem.getOutputDirectory(),
-                artifactItem.getIncludes(), artifactItem.getExcludes() );
+                artifactItem.getIncludes(), artifactItem.getExcludes(), artifactItem.getEncoding() );
         handler.setMarker();
     }
 

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/UnpackDependenciesMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/UnpackDependenciesMojo.java
@@ -69,6 +69,13 @@ public class UnpackDependenciesMojo
     private String excludes;
 
     /**
+     * Encoding of artifact.
+     *
+     */
+    @Parameter( property = "mdep.unpack.encoding" )
+    private String encoding;
+
+    /**
      * Main entry into mojo. This method gets the dependencies and iterates
      * through each one passing it to DependencyUtil.unpackFile().
      *
@@ -89,7 +96,7 @@ public class UnpackDependenciesMojo
             destDir = DependencyUtil.getFormattedOutputDirectory( useSubDirectoryPerScope, useSubDirectoryPerType,
                                                                   useSubDirectoryPerArtifact, useRepositoryLayout,
                                                                   stripVersion, outputDirectory, artifact );
-            unpack( artifact, destDir, getIncludes(), getExcludes() );
+            unpack( artifact, destDir, getIncludes(), getExcludes(), getEncoding() );
             DefaultFileMarkerHandler handler = new DefaultFileMarkerHandler( artifact, this.markersDirectory );
             handler.setMarker();
         }
@@ -139,5 +146,21 @@ public class UnpackDependenciesMojo
     public void setIncludes( String includes )
     {
         this.includes = includes;
+    }
+
+    /**
+     * @param encoding The encoding to set.
+     */
+    public void setEncoding( String encoding )
+    {
+        this.encoding = encoding;
+    }    
+
+    /**
+     * @return Returns the encoding.
+     */
+    public String getEncoding()
+    {
+        return this.encoding;
     }
 }


### PR DESCRIPTION
Sometimes there is a need to unpack ZIP files which are encoded in particular encodings. As it is impossible to automatically detect the encoding of a ZIP file, a new optional parameter now supports customizing the encoding applied when running unpacking goals.
