### PR TITLE
LinkMojo creates symbolic links to artifacts

### DIFF
--- a/maven-dependency-plugin/pom.xml
+++ b/maven-dependency-plugin/pom.xml
@@ -178,7 +178,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.24</version>
+      <version>3.0.25-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/LinkMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/LinkMojo.java
@@ -1,0 +1,187 @@
+package org.apache.maven.plugins.dependency.fromConfiguration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.dependency.utils.filters.ArtifactItemFilter;
+import org.apache.maven.plugins.dependency.utils.filters.DestFileFilter;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Goal that creates links to a list of artifacts in the repository.
+ *
+ * @author <a href="mailto:markus@headcrashing.eu">Markus KARG</a>
+ * @version $Id$
+ * @since 3.0
+ */
+@Mojo( name = "link", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = false, threadSafe = true  )
+public class LinkMojo
+    extends AbstractFromConfigurationMojo
+{
+
+    /**
+     * Strip artifact version during link
+     */
+    @Parameter( property = "mdep.stripVersion", defaultValue = "false" )
+    private boolean stripVersion = false;
+
+    /**
+     * Strip artifact classifier during link
+     */
+    @Parameter( property = "mdep.stripClassifier", defaultValue = "false" )
+    private boolean stripClassifier = false;
+    
+    /**
+     * Prepend artifact groupId during link
+     * @since 2.7
+     */
+    @Parameter( property = "mdep.prependGroupId", defaultValue = "false" )
+    private boolean prependGroupId = false;
+
+    /**
+     * Use artifact baseVersion during link
+     * @since 2.7
+     */
+    @Parameter( property = "mdep.useBaseVersion", defaultValue = "false" )
+    private boolean useBaseVersion = false;
+
+    /**
+     * The artifact to link to from commandLine.
+     * Use {@link #artifactItems} within the pom-configuration.
+     */
+    @SuppressWarnings( "unused" ) //marker-field, setArtifact(String) does the magic
+    @Parameter( property = "artifact" )
+    private String artifact;
+
+    /**
+     * <i>not used in this goal</i>
+     */
+    @Parameter
+    protected boolean useJvmChmod = true;
+
+    /**
+     * <i>not used in this goal</i>
+     */
+    @Parameter
+    protected boolean ignorePermissions;
+
+    /**
+     * Main entry into mojo. This method gets the ArtifactItems and iterates through each one passing it to
+     * linkArtifact.
+     *
+     * @throws MojoExecutionException with a message if an error occurs.
+     * @see ArtifactItem
+     * @see #getArtifactItems
+     * @see #linkArtifact(ArtifactItem)
+     */
+    @Override
+    protected void doExecute()
+        throws MojoExecutionException, MojoFailureException
+    {
+        verifyRequirements();
+
+        List<ArtifactItem> theArtifactItems =
+            getProcessedArtifactItems( new ProcessArtifactItemsRequest( stripVersion, prependGroupId,
+                                                                        useBaseVersion, stripClassifier ) );
+        for ( ArtifactItem artifactItem : theArtifactItems )
+        {
+            if ( artifactItem.isNeedsProcessing() )
+            {
+                linkArtifact( artifactItem );
+            }
+            else
+            {
+                this.getLog().info( artifactItem + " already exists in " + artifactItem.getOutputDirectory() );
+            }
+        }
+    }
+
+    /**
+     * Resolves the artifact from the repository and links to it from the specified location.
+     *
+     * @param artifactItem containing the information about the Artifact to link.
+     * @throws MojoExecutionException with a message if an error occurs.
+     * @see DependencyUtil#linkFile(File, File, Log)
+     * @see DependencyUtil#getFormattedFileName(Artifact, boolean)
+     */
+    protected void linkArtifact( ArtifactItem artifactItem )
+        throws MojoExecutionException
+    {
+        File destFile = new File( artifactItem.getOutputDirectory(), artifactItem.getDestFileName() );
+
+        linkFile( artifactItem.getArtifact().getFile(), destFile );
+    }
+
+    @Override
+    protected ArtifactItemFilter getMarkedArtifactFilter( ArtifactItem item )
+    {
+        ArtifactItemFilter destinationNameOverrideFilter =
+            new DestFileFilter( this.isOverWriteReleases(), this.isOverWriteSnapshots(), this.isOverWriteIfNewer(),
+                                false, false, false, false, this.stripVersion, prependGroupId, useBaseVersion,
+                                item.getOutputDirectory() );
+        return destinationNameOverrideFilter;
+    }
+
+    /**
+     * @return Returns the stripVersion.
+     */
+    public boolean isStripVersion()
+    {
+        return this.stripVersion;
+    }
+
+    /**
+     * @param stripVersion The stripVersion to set.
+     */
+    public void setStripVersion( boolean stripVersion )
+    {
+        this.stripVersion = stripVersion;
+    }
+    
+    /**
+     * @return Returns the stripClassifier.
+     */
+    public boolean isStripClassifier()
+    {
+        return this.stripClassifier;
+    }
+
+    /**
+     * @param stripClassifier The stripClassifier to set.
+     */
+    public void setStripClassifier( boolean stripClassifier )
+    {
+        this.stripClassifier = stripClassifier;
+    }
+
+    /**
+     * @param useBaseVersion The useBaseVersion to set.
+     */
+    public void setUseBaseVersion( boolean useBaseVersion )
+    {
+        this.useBaseVersion = useBaseVersion;
+    }
+}

--- a/maven-dependency-plugin/src/site/apt/index.apt.vm
+++ b/maven-dependency-plugin/src/site/apt/index.apt.vm
@@ -70,6 +70,8 @@ ${project.name}
   *{{{./go-offline-mojo.html}dependency:go-offline}} tells Maven to resolve everything this project is dependent on
   (dependencies, plugins, reports) in preparation for going offline.
 
+  *{{{./link-mojo.html}dependency:link}} like copy but creates symbolic links.
+
   *{{{./list-mojo.html}dependency:list}} alias for resolve that lists the dependencies for this project.
 
   *{{{./list-repositories-mojo.html}dependency:list-repositories}} displays all project dependencies and then lists the repositories used.

--- a/maven-dependency-plugin/src/site/fml/faq.fml
+++ b/maven-dependency-plugin/src/site/fml/faq.fml
@@ -78,6 +78,14 @@ under the License.
         </p>
       </answer>
     </faq>
+    <faq id="link-insufficient-rights">
+      <question>Why do I get "You do not have sufficient privilege to perform this operation" when using the link goal?</question>
+      <answer><p>
+        This is a security constraint of the Windows(R) operating system. By default, it prevents anybody to create symbolic links besides administrators in elevated mode.
+        Either execute Maven as an administrator in elevated mode, or as a plain user having explicitly granted the right "Create symbolic links" by an administrator.
+      </p>
+      </answer>
+    </faq>
     <faq id="unused">
       <question>Why does my dependency analysis report <code>Unused declared dependencies</code>?</question>
       <answer><p>

--- a/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestLinkMojo.java
+++ b/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestLinkMojo.java
@@ -1,0 +1,837 @@
+package org.apache.maven.plugins.dependency.fromConfiguration;
+
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.    
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.dependency.AbstractDependencyMojoTestCase;
+import org.apache.maven.plugins.dependency.utils.DependencyUtil;
+import org.apache.maven.project.MavenProject;
+import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
+import org.sonatype.aether.util.DefaultRepositorySystemSession;
+
+public class TestLinkMojo
+    extends AbstractDependencyMojoTestCase
+{
+    LinkMojo mojo;
+
+    public TestLinkMojo()
+    {
+        super();
+    }
+
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp( "link", false, false );
+
+        File testPom = new File( getBasedir(), "target/test-classes/unit/link-test/plugin-config.xml" );
+        mojo = (LinkMojo) lookupMojo( "link", testPom );
+        mojo.setOutputDirectory( new File( this.testDir, "outputDirectory" ) );
+        mojo.setSilent( true );
+
+        assertNotNull( mojo );
+        assertNotNull( mojo.getProject() );
+        // MavenProject project = mojo.getProject();
+        // init classifier things
+        
+        MavenSession session = newMavenSession( mojo.getProject() );
+        setVariableValueToObject( mojo, "session", session );
+        
+        DefaultRepositorySystemSession repoSession = (DefaultRepositorySystemSession) session.getRepositorySession();
+        
+        repoSession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( stubFactory.getWorkingDir() ) );
+    }
+
+    public ArtifactItem getSingleArtifactItem( boolean removeVersion, boolean useBaseVersion )
+        throws MojoExecutionException
+    {
+        List<ArtifactItem> list = mojo.getProcessedArtifactItems(new ProcessArtifactItemsRequest( removeVersion, false, useBaseVersion, false ));
+        return list.get( 0 );
+    }
+
+    public void testGetArtifactItems()
+        throws Exception
+    {
+
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifact" );
+        item.setGroupId( "groupId" );
+        item.setVersion( "1.0" );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>( 1 );
+        list.add( createArtifact( item ) );
+
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+
+        ArtifactItem result = getSingleArtifactItem( false, false );
+        assertEquals( mojo.getOutputDirectory(), result.getOutputDirectory() );
+
+        File output = new File( mojo.getOutputDirectory(), "override" );
+        item.setOutputDirectory( output );
+        result = getSingleArtifactItem( false, false );
+        assertEquals( output, result.getOutputDirectory() );
+    }
+
+    public void assertFilesExist( Collection<ArtifactItem> items, boolean exist )
+    {
+        for ( ArtifactItem item : items )
+        {
+            assertFileExists( item, exist );
+        }
+    }
+
+    public void assertFileExists( ArtifactItem item, boolean exist )
+    {
+        File file = new File( item.getOutputDirectory(), item.getDestFileName() );
+        assertEquals( exist, file.exists() );
+    }
+
+    public void testMojoDefaults()
+    {
+        LinkMojo themojo = new LinkMojo();
+
+        assertFalse( themojo.isStripVersion() );
+        assertFalse( themojo.isSkip() );
+        assertFalse( themojo.isStripClassifier() );
+    }
+
+    public void testLinkFile()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+
+        mojo.execute();
+
+        assertFilesExist( list, true );
+    }
+    
+    public void testLinkFileWithBaseVersion()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifact" );
+        item.setGroupId( "groupId" );
+        item.setVersion( "1.0-20130210.213424-191" );
+        list.add(item);
+
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+        mojo.setUseBaseVersion(true);
+
+        mojo.execute();
+
+        assertFilesExist( list, true );
+    }
+    
+    public void testSkip()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+
+        mojo.setSkip( true );
+        mojo.setArtifactItems( list );
+
+        mojo.execute();
+        for ( ArtifactItem item : list )
+        {
+            //these will be null because no processing has occured only when everything is skipped
+            assertEquals( null, item.getOutputDirectory() );
+            assertEquals( null, item.getDestFileName() );
+        }
+
+    }
+
+    public void testLinkFileNoOverwrite()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+
+        for ( ArtifactItem item : list )
+        {
+            // make sure that we link even if false is set - MDEP-80
+            item.setOverWrite( "false" );
+        }
+
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+        mojo.execute();
+
+        assertFilesExist( list, true );
+    }
+
+    public void testLinkToLocation()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+        ArtifactItem item = list.get( 0 );
+        item.setOutputDirectory( new File( mojo.getOutputDirectory(), "testOverride" ) );
+
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+
+        mojo.execute();
+
+        assertFilesExist( list, true );
+    }
+
+    public void testLinkStripVersionSetInMojo()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+        
+        ArtifactItem item = list.get( 0 );
+        item.setOutputDirectory( new File( mojo.getOutputDirectory(), "testOverride" ) );
+        mojo.setStripVersion( true );
+
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+
+        mojo.execute();
+        assertEquals( DependencyUtil.getFormattedFileName( item.getArtifact(), true ), item.getDestFileName() );
+
+        assertFilesExist( list, true );
+    }
+
+    public void testLinkStripClassifierSetInMojo()
+            throws Exception
+        {
+            List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+            
+            ArtifactItem item = list.get( 0 );
+            item.setOutputDirectory( new File( mojo.getOutputDirectory(), "testOverride" ) );
+            mojo.setStripClassifier( true );
+
+            mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+
+            mojo.execute();
+            assertEquals( DependencyUtil.getFormattedFileName( item.getArtifact(), false, false, false, true ), item.getDestFileName() );
+
+            assertFilesExist( list, true );
+        }
+    
+    public void testNonClassifierStrip()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getReleaseAndSnapshotArtifacts() );
+        mojo.setStripVersion( true );
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+
+        mojo.execute();
+
+        assertFilesExist( list, true );
+    }
+
+    public void testNonClassifierNoStrip()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getReleaseAndSnapshotArtifacts() );
+
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+
+        mojo.execute();
+
+        assertFilesExist( list, true );
+    }
+
+    public void testMissingVersionNotFound()
+        throws Exception
+    {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId" );
+        item.setClassifier( "" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>();
+        list.add( item );
+        mojo.setArtifactItems( list );
+
+        try
+        {
+            mojo.execute();
+            fail( "Expected Exception Here." );
+        }
+        catch ( MojoExecutionException e )
+        {
+            // caught the expected exception.
+        }
+    }
+
+    public List<Dependency> getDependencyList( ArtifactItem item )
+    {
+        Dependency dep = new Dependency();
+        dep.setArtifactId( item.getArtifactId() );
+        dep.setClassifier( item.getClassifier() );
+        dep.setGroupId( item.getGroupId() );
+        dep.setType( item.getType() );
+        dep.setVersion( "2.0-SNAPSHOT" );
+
+        Dependency dep2 = new Dependency();
+        dep2.setArtifactId( item.getArtifactId() );
+        dep2.setClassifier( "classifier" );
+        dep2.setGroupId( item.getGroupId() );
+        dep2.setType( item.getType() );
+        dep2.setVersion( "2.1" );
+
+        List<Dependency> list = new ArrayList<Dependency>( 2 );
+        list.add( dep2 );
+        list.add( dep );
+
+        return list;
+    }
+
+    public void testMissingVersionFromDependencies()
+        throws Exception
+    {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId" );
+        item.setClassifier( "" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>();
+        list.add( item );
+        mojo.setArtifactItems( list );
+
+        MavenProject project = mojo.getProject();
+        project.setDependencies( createDependencyArtifacts( getDependencyList( item ) ) );
+
+        mojo.execute();
+        this.assertFileExists( item, true );
+        assertEquals( "2.0-SNAPSHOT", item.getVersion() );
+    }
+
+    public void testMissingVersionFromDependenciesLooseMatch()
+        throws Exception
+    {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId" );
+        item.setClassifier( "" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        MavenProject project = mojo.getProject();
+        project.setDependencies( createDependencyArtifacts( getDependencyList( item ) ) );
+        
+        // ensure dependency exists
+        item.setClassifier( "sources" );
+        item.setType( "jar" );
+        
+        // pre-create item
+        item.setVersion( "2.1" );
+        createArtifact( item );
+        item.setVersion( null );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>();
+        list.add( item );
+        mojo.setArtifactItems( list );
+
+        mojo.execute();
+        this.assertFileExists( item, true );
+        assertEquals( "2.1", item.getVersion() );
+    }
+
+    public void testMissingVersionFromDependenciesWithClassifier()
+        throws Exception
+    {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId" );
+        item.setClassifier( "classifier" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>();
+        list.add( item );
+        mojo.setArtifactItems( list );
+
+        MavenProject project = mojo.getProject();
+        project.setDependencies( createDependencyArtifacts( getDependencyList( item ) ) );
+
+        mojo.execute();
+        this.assertFileExists( item, true );
+        assertEquals( "2.1", item.getVersion() );
+    }
+
+    public List<Dependency> getDependencyMgtList( ArtifactItem item )
+    {
+        Dependency dep = new Dependency();
+        dep.setArtifactId( item.getArtifactId() );
+        dep.setClassifier( item.getClassifier() );
+        dep.setGroupId( item.getGroupId() );
+        dep.setType( item.getType() );
+        dep.setVersion( "3.0-SNAPSHOT" );
+
+        Dependency dep2 = new Dependency();
+        dep2.setArtifactId( item.getArtifactId() );
+        dep2.setClassifier( "classifier" );
+        dep2.setGroupId( item.getGroupId() );
+        dep2.setType( item.getType() );
+        dep2.setVersion( "3.1" );
+
+        List<Dependency> list = new ArrayList<Dependency>( 2 );
+        list.add( dep2 );
+        list.add( dep );
+
+        return list;
+    }
+
+    public void testMissingVersionFromDependencyMgt()
+        throws Exception
+    {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId" );
+        item.setClassifier( "" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        MavenProject project = mojo.getProject();
+        project.setDependencies( getDependencyList( item ) );
+
+        item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId-2" );
+        item.setClassifier( "" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>();
+        list.add( item );
+
+        mojo.setArtifactItems( list );
+
+        project.getDependencyManagement().setDependencies( createDependencyArtifacts( getDependencyMgtList( item ) ) );
+
+        mojo.execute();
+
+        this.assertFileExists( item, true );
+        assertEquals( "3.0-SNAPSHOT", item.getVersion() );
+    }
+
+    public void testMissingVersionFromDependencyMgtLooseMatch()
+        throws Exception
+    {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId" );
+        item.setClassifier( "" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        MavenProject project = mojo.getProject();
+        project.setDependencies( getDependencyList( item ) );
+
+        item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId-2" );
+        item.setClassifier( "" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>();
+        list.add( item );
+
+        mojo.setArtifactItems( list );
+
+        project.getDependencyManagement().setDependencies( createDependencyArtifacts( getDependencyMgtList( item ) ) );
+
+        item.setType( "jar" );
+
+        // pre-create item
+        item.setVersion( "3.1" );
+        createArtifact( item );
+        item.setVersion( null );
+
+        mojo.execute();
+
+        this.assertFileExists( item, true );
+        assertEquals( "3.1", item.getVersion() );
+    }
+
+    public void testMissingVersionFromDependencyMgtWithClassifier()
+        throws Exception
+    {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId" );
+        item.setClassifier( "classifier" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        MavenProject project = mojo.getProject();
+        project.setDependencies( getDependencyList( item ) );
+
+        item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId-2" );
+        item.setClassifier( "classifier" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>();
+        list.add( item );
+
+        mojo.setArtifactItems( list );
+
+        project.getDependencyManagement().setDependencies( createDependencyArtifacts( getDependencyMgtList( item ) ) );
+
+        mojo.execute();
+
+        this.assertFileExists( item, true );
+        assertEquals( "3.1", item.getVersion() );
+    }
+
+    public void testArtifactNotFound()
+        throws Exception
+    {
+        dotestArtifactExceptions( false, true );
+    }
+
+    public void testArtifactResolutionException()
+        throws Exception
+    {
+        dotestArtifactExceptions( true, false );
+    }
+
+    public void dotestArtifactExceptions( boolean are, boolean anfe )
+        throws Exception
+    {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setArtifactId( "artifactId" );
+        item.setClassifier( "" );
+        item.setGroupId( "groupId" );
+        item.setType( "type" );
+        item.setVersion( "1.0" );
+
+        List<ArtifactItem> list = new ArrayList<ArtifactItem>();
+        list.add( item );
+        mojo.setArtifactItems( list );
+
+        try
+        {
+            mojo.execute();
+            fail( "ExpectedException" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            assertEquals( "Unable to find/resolve artifact.", e.getMessage() );
+        }
+    }
+
+    public void testNoArtifactItems()
+    {
+        try
+        {
+            mojo.getProcessedArtifactItems( new ProcessArtifactItemsRequest( false, false, false, false ) );
+            fail( "Expected Exception" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            assertEquals( "There are no artifactItems configured.", e.getMessage() );
+        }
+
+    }
+
+    public void testLinkDontOverWriteReleases()
+        throws Exception
+    {
+
+        /*
+         * Given an existing link is pointing to an existing artifact
+         */
+
+        stubFactory.setCreateFiles( true );
+        final String linkName = "the-link.jar";
+        
+        Artifact existingArtifact = stubFactory.getSnapshotArtifact();
+        ArtifactItem existingItem = new ArtifactItem( existingArtifact );
+        existingItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( existingItem ) );
+        mojo.execute();
+
+
+        /*
+         * When trying to overwrite that link so it is pointing to a release artifact while having overwriteIfNewer
+         * disabled
+         */
+        
+        Artifact newArtifact = stubFactory.getReleaseArtifact();
+        ArtifactItem newItem = new ArtifactItem( newArtifact );
+        newItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( newItem ) );
+        mojo.setOverWriteIfNewer( false );
+        mojo.execute();
+
+        
+        /*
+         * Then that link must still point to the original artifact
+         */
+        
+        Path existingFile = existingArtifact.getFile().toPath();
+        Path linkFile = newItem.getOutputDirectory().toPath().resolve( newItem.getDestFileName() );
+
+        assertTrue( Files.isSameFile( linkFile, existingFile ) );
+    }
+
+    public void testLinkDontOverWriteSnapshots()
+        throws Exception
+    {
+
+        /*
+         * Given an existing link is pointing to an existing artifact
+         */
+
+        stubFactory.setCreateFiles( true );
+        final String linkName = "the-link.jar";
+        
+        Artifact existingArtifact = stubFactory.getSnapshotArtifact();
+        ArtifactItem existingItem = new ArtifactItem( existingArtifact );
+        existingItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( existingItem ) );
+        mojo.execute();
+
+
+        /*
+         * When trying to overwrite that link so it is pointing to a snapshot artifact while having overwriteIfNewer
+         * disabled
+         */
+        
+        Artifact newArtifact = stubFactory.getSnapshotArtifact();
+        ArtifactItem newItem = new ArtifactItem( newArtifact );
+        newItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( newItem ) );
+        mojo.setOverWriteIfNewer( false );
+        mojo.execute();
+
+        
+        /*
+         * Then that link must still point to the original artifact
+         */
+        
+        Path existingFile = existingArtifact.getFile().toPath();
+        Path linkFile = newItem.getOutputDirectory().toPath().resolve( newItem.getDestFileName() );
+
+        assertTrue( Files.isSameFile( linkFile, existingFile ) );
+    }
+
+    public void testLinkOverWriteReleases()
+        throws Exception
+    {
+
+        /*
+         * Given an existing link is pointing to an existing artifact
+         */
+
+        stubFactory.setCreateFiles( true );
+        final String linkName = "the-link.jar";
+        
+        Artifact existingArtifact = stubFactory.getSnapshotArtifact();
+        ArtifactItem existingItem = new ArtifactItem( existingArtifact );
+        existingItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( existingItem ) );
+        mojo.execute();
+
+
+        /*
+         * When trying to overwrite that link so it is pointing to a release artifact while having overwriteReleases
+         * enabled
+         */
+        
+        Artifact newArtifact = stubFactory.getReleaseArtifact();
+        ArtifactItem newItem = new ArtifactItem( newArtifact );
+        newItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( newItem ) );
+        mojo.setOverWriteIfNewer( false );
+        mojo.setOverWriteReleases( true );
+        mojo.execute();
+
+        
+        /*
+         * Then that link must now point to the new release artifact
+         */
+        
+        Path newFile = newArtifact.getFile().toPath();
+        Path linkFile = newItem.getOutputDirectory().toPath().resolve( newItem.getDestFileName() );
+
+        assertTrue( Files.isSameFile( linkFile, newFile ) );
+    }
+
+    public void testLinkOverWriteSnapshot()
+        throws Exception
+    {
+
+        /*
+         * Given an existing link is pointing to an existing artifact
+         */
+
+        stubFactory.setCreateFiles( true );
+        final String linkName = "the-link.jar";
+        
+        Artifact existingArtifact = stubFactory.getSnapshotArtifact();
+        ArtifactItem existingItem = new ArtifactItem( existingArtifact );
+        existingItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( existingItem ) );
+        mojo.execute();
+
+
+        /*
+         * When trying to overwrite that link so it is pointing to a snapshot artifact while having overwriteSnapshots
+         * enabled
+         */
+        
+        Artifact newArtifact = stubFactory.getSnapshotArtifact();
+        ArtifactItem newItem = new ArtifactItem( newArtifact );
+        newItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( newItem ) );
+        mojo.setOverWriteIfNewer( false );
+        mojo.setOverWriteReleases( false );
+        mojo.setOverWriteSnapshots( true );
+        mojo.execute();
+
+        
+        /*
+         * Then that link must now point to the new snapshot artifact
+         */
+        
+        Path newFile = newArtifact.getFile().toPath();
+        Path linkFile = newItem.getOutputDirectory().toPath().resolve( newItem.getDestFileName() );
+
+        assertTrue( Files.isSameFile( linkFile, newFile ) );
+    }
+
+    public void testLinkOverWriteIfNewer()
+        throws Exception
+    {
+
+        /*
+         * Given an existing link is pointing to an existing artifact
+         */
+
+        stubFactory.setCreateFiles( true );
+        final String linkName = "the-link.jar";
+        
+        Artifact existingArtifact = stubFactory.getSnapshotArtifact();
+        ArtifactItem existingItem = new ArtifactItem( existingArtifact );
+        existingItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( existingItem ) );
+        mojo.execute();
+
+
+        /*
+         * When trying to overwrite that link so it is pointing to a new artifact while having overwriteIfNewer
+         * enabled
+         */
+        
+        Artifact newArtifact = stubFactory.getReleaseArtifact();
+        ArtifactItem newItem = new ArtifactItem( newArtifact );
+        newItem.setDestFileName( linkName );
+        mojo.setArtifactItems( Arrays.asList( newItem ) );
+        mojo.setOverWriteIfNewer( true );
+        mojo.execute();
+
+        
+        /*
+         * Then that link must now point to the new artifact
+         */
+        
+        Path newFile = newArtifact.getFile().toPath();
+        Path linkFile = newItem.getOutputDirectory().toPath().resolve( newItem.getDestFileName() );
+
+        assertTrue( Files.isSameFile( linkFile, newFile ) );
+    }
+    
+    public void testLinkFileWithOverideLocalRepo()
+        throws Exception
+    {
+        final File localRepo = stubFactory.getWorkingDir();
+        
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+
+        mojo.setArtifactItems( list );
+        
+        File execLocalRepo =  new File( this.testDir.getAbsolutePath(), "executionLocalRepo" );
+        assertFalse( execLocalRepo.exists() );
+        
+        stubFactory.setWorkingDir( execLocalRepo );
+        createArtifactItemArtifacts( list );
+        
+        assertFalse( "default local repo should not exist", localRepo.exists() );
+        
+        mojo.setLocalRepositoryDirectory( execLocalRepo );
+        
+        mojo.execute();
+
+        assertFilesExist( list, true );
+       
+    }    
+
+    private List<Dependency> createDependencyArtifacts( List<Dependency> items ) throws IOException {
+        stubFactory.setCreateFiles( true );
+        for ( Dependency item : items )
+        {
+            String classifier = "".equals( item.getClassifier() ) ? null : item.getClassifier();
+            stubFactory.createArtifact( item.getGroupId(), item.getArtifactId(),
+                                        VersionRange.createFromVersion( item.getVersion() ), null,
+                                        item.getType(), classifier, item.isOptional() );
+        }
+        return items;
+    }
+    
+    private List<ArtifactItem> createArtifactItemArtifacts( List<ArtifactItem> items )
+        throws IOException
+    {
+        for ( ArtifactItem item : items )
+        {
+            createArtifact( item );
+        }
+        return items;
+    }
+
+    private ArtifactItem createArtifact( ArtifactItem item ) throws IOException
+    {
+        stubFactory.setCreateFiles( true );
+        
+        String classifier = "".equals( item.getClassifier() ) ? null : item.getClassifier(); 
+        String version = item.getVersion() != null ? item.getVersion() : item.getBaseVersion();
+        stubFactory.createArtifact( item.getGroupId(), item.getArtifactId(),
+                                    version, null,
+                                    item.getType(), classifier );
+        return item;
+    }
+}

--- a/maven-dependency-plugin/src/test/resources/unit/link-test/plugin-config.xml
+++ b/maven-dependency-plugin/src/test/resources/unit/link-test/plugin-config.xml
@@ -1,0 +1,38 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License. 
+ *
+-->
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+              <project implementation="org.apache.maven.plugins.dependency.testUtils.stubs.DependencyProjectStub"/>
+          </configuration>
+      </plugin>
+    </plugins>
+  </build>
+    <dependencies>
+        <dependency>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-artifact</artifactId>
+          <version>2.0.4</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
This new mojo does the same as the copy mojo, but instead of really moving bytes around it simply creates symbolic links to the original storage location. When having to copy large amounts of data just for the sake of getting a particular on-disk structure in the end, this new mojo can spare huge amounts of time -- and plenty of disk space.

Warning: Windows requires users to have right to create symlinks, which by default only admins have in elevated mode. Hence TestLinkMojo and LinkMojo both will fail if not executed with sufficient access rights and / or elevated mode. This is not a bug but intended beavior of the Windows(R) operating system family. To effectively work with this mojo the user account should be a _non-administrator_, which got _assigned the needed access rights_ by an administrator.

**Note: This PR discovers a bug in plexus-utils, hence bug fix found in [PR 13](https://github.com/codehaus-plexus/plexus-utils/pull/13) is essentially needed to pass tests!**
