### PR TITLE
Reintroduce verbose support for dependency:tree

### DIFF
--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/tree/TGFDependencyNodeVisitor.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/tree/TGFDependencyNodeVisitor.java
@@ -20,9 +20,9 @@ package org.apache.maven.plugins.dependency.tree ;
  */
 
 import java.io.Writer;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -104,9 +104,9 @@ public class TGFDependencyNodeVisitor
     }
 
     /**
-     * List of edges.
+     * Edges by id.
      */
-    private List<EdgeAppender> edges = new ArrayList<EdgeAppender>();
+    private Map<String, EdgeAppender> edges = new LinkedHashMap<String, EdgeAppender>();
 
     /**
      * Set of node ids.
@@ -157,7 +157,7 @@ public class TGFDependencyNodeVisitor
         {
             // dump edges on last node endVisit
             writer.println( "#" );
-            for ( EdgeAppender edge : edges )
+            for ( EdgeAppender edge : edges.values() )
             {
                 writer.println( edge.asString( mergeVersion ) );
             }
@@ -171,7 +171,10 @@ public class TGFDependencyNodeVisitor
                 // using scope as edge label.
                 label = node.getArtifact().getScope();
             }
-            edges.add( new EdgeAppender( p, node, label ) );
+            String fromId = generateId( p, mergeVersion );
+            String toId = generateId( node, mergeVersion );
+            // avoid duplicates (in case of verbose)
+            edges.put( fromId + toId, new EdgeAppender( p, node, label ) );
         }
         return true;
     }

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/tree/TreeMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/tree/TreeMojo.java
@@ -115,6 +115,27 @@ public class TreeMojo
     private String outputType;
 
     /**
+     * If specified, this parameter will cause that the scope is not included in the output.
+     * <p/>
+     * Note that this is only supported by the outputType "tgf" at the moment.
+     *
+     * @since 3.0
+     */
+    @Parameter( property = "outputScope", defaultValue = "true" )
+    private boolean outputScope;
+
+    /**
+     * If specified, this parameter will cause that dependencies with the same groupId, artifactId, type and classifier
+     * are merged even if the version are different.
+     * <p/>
+     * Note that this is only supported by the outputType "tgf" at the moment.
+     *
+     * @since 3.0
+     */
+    @Parameter( property = "outputMergeVersion", defaultValue = "false" )
+    private boolean outputMergeVersion;
+
+    /**
      * The scope to filter by when resolving the dependency tree, or <code>null</code> to include dependencies from
      * all scopes. Note that this feature does not currently work due to MSHARED-4
      *
@@ -363,7 +384,7 @@ public class TreeMojo
         }
         else if ( "tgf".equals( outputType ) )
         {
-            return new TGFDependencyNodeVisitor( writer );
+            return new TGFDependencyNodeVisitor( writer, outputScope, outputMergeVersion );
         }
         else if ( "dot".equals( outputType ) )
         {


### PR DESCRIPTION
This patch reintroduce the support of the "verbose" parameter for dependency:tree.
This feature was removed as part of MDEP-494.
