### PR TITLE
Do not enable failOnMissingClassifierArtifact by default

### DIFF
--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/AbstractFromDependenciesMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/AbstractFromDependenciesMojo.java
@@ -95,7 +95,7 @@ public abstract class AbstractFromDependenciesMojo
      * @since 2.0-alpha-2
      */
     @Parameter( property = "mdep.failOnMissingClassifierArtifact", defaultValue = "false" )
-    protected boolean failOnMissingClassifierArtifact = true;
+    protected boolean failOnMissingClassifierArtifact;
 
     /**
      * @return Returns the outputDirectory.


### PR DESCRIPTION
In the docs it says the default is "false", which also is the safer choice,
so align the actual initialization with the "defaultValue".
