### PR TITLE
MDEPLOY-214: Added property "retryFailedDeploymentDelay" on maven-deploy-plugin

### DIFF
--- a/maven-deploy-plugin/src/main/java/org/apache/maven/plugins/deploy/AbstractDeployMojo.java
+++ b/maven-deploy-plugin/src/main/java/org/apache/maven/plugins/deploy/AbstractDeployMojo.java
@@ -66,6 +66,15 @@ public abstract class AbstractDeployMojo
     @Parameter( property = "retryFailedDeploymentCount", defaultValue = "1" )
     private int retryFailedDeploymentCount;
 
+    /**
+     * Parameter used to control how much time (in seconds) a failed deployment will be retried after a failed
+     * connection.
+     *
+     * @since 2.9
+     */
+    @Parameter( property = "retryFailedDeploymentDelay", defaultValue = "20" )
+    private int retryFailedDeploymentDelay;
+
     @Parameter( defaultValue = "${session}", readonly = true, required = true )
     private MavenSession session;
     
@@ -101,6 +110,11 @@ public abstract class AbstractDeployMojo
     int getRetryFailedDeploymentCount()
     {
         return retryFailedDeploymentCount;
+    }
+
+    int getRetryFailedDeploymentDelay()
+    {
+        return retryFailedDeploymentDelay;
     }
 
     protected ArtifactRepository createDeploymentArtifactRepository( String id, String url,

--- a/maven-deploy-plugin/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
+++ b/maven-deploy-plugin/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
@@ -151,6 +151,7 @@ public class DeployMojo
                 .setProject( project )
                 .setUpdateReleaseInfo( isUpdateReleaseInfo() )
                 .setRetryFailedDeploymentCount( getRetryFailedDeploymentCount() )
+                .setRetryFailedDeploymentDelay( getRetryFailedDeploymentDelay() )
                 .setAltReleaseDeploymentRepository( altReleaseDeploymentRepository )
                 .setAltSnapshotDeploymentRepository( altSnapshotDeploymentRepository )
                 .setAltDeploymentRepository( altDeploymentRepository );


### PR DESCRIPTION
This property impose a delay between 0 seconds to 5 minutes (max)
between retries. Default value: 20 seconds. The intention is to
make maven-deploy-plugin more solid and stable when network
glitches happens.

ticket https://issues.apache.org/jira/browse/MDEPLOY-214
in maven-deploy-plugin has the details.
