### PR TITLE
Correct jira.codehaus.org to issues.apache.org/jira

### DIFF
--- a/maven-changelog-plugin/src/main/java/org/apache/maven/plugin/changelog/ChangeLogReport.java
+++ b/maven-changelog-plugin/src/main/java/org/apache/maven/plugin/changelog/ChangeLogReport.java
@@ -337,7 +337,7 @@ public class ChangeLogReport
      *
      * @since 2.2
      */
-    @Parameter( property = "issueLinkUrl", defaultValue = "http://jira.codehaus.org/browse/%ISSUE%", required = true )
+    @Parameter( property = "issueLinkUrl", defaultValue = "https://issues.apache.org/jira/browse/%ISSUE%", required = true )
     private String issueLinkUrl;
 
     /**

--- a/maven-changes-plugin/src/test/java/org/apache/maven/plugin/jira/JiraHelperTestCase.java
+++ b/maven-changes-plugin/src/test/java/org/apache/maven/plugin/jira/JiraHelperTestCase.java
@@ -37,30 +37,30 @@ public class JiraHelperTestCase
     {
         Map<String, String> map;
 
-        map = JiraHelper.getJiraUrlAndProjectId( "http://jira.codehaus.org/browse/DOXIA" );
-        assertEquals( "http://jira.codehaus.org", map.get( "url" ) );
+        map = JiraHelper.getJiraUrlAndProjectId( "https://issues.apache.org/jira/browse/DOXIA" );
+        assertEquals( "https://issues.apache.org/jira", map.get( "url" ) );
 
         // MCHANGES-218
-        map = JiraHelper.getJiraUrlAndProjectId( "http://jira.codehaus.org/browse/DOXIA/" );
-        assertEquals( "http://jira.codehaus.org", map.get( "url" ) );
+        map = JiraHelper.getJiraUrlAndProjectId( "https://issues.apache.org/jira/browse/DOXIA/" );
+        assertEquals( "https://issues.apache.org/jira", map.get( "url" ) );
 
         // MCHANGES-222
         map =
-            JiraHelper.getJiraUrlAndProjectId( "http://jira.codehaus.org/secure/IssueNavigator.jspa?pid=11761&reset=true" );
-        assertEquals( "http://jira.codehaus.org", map.get( "url" ) );
-        map = JiraHelper.getJiraUrlAndProjectId( "http://jira.codehaus.org/browse/MSHARED/component/13380" );
-        assertEquals( "http://jira.codehaus.org", map.get( "url" ) );
+            JiraHelper.getJiraUrlAndProjectId( "https://issues.apache.org/jira/secure/IssueNavigator.jspa?pid=11761&reset=true" );
+        assertEquals( "https://issues.apache.org/jira", map.get( "url" ) );
+        map = JiraHelper.getJiraUrlAndProjectId( "https://issues.apache.org/jira/browse/MSHARED/component/13380" );
+        assertEquals( "https://issues.apache.org/jira", map.get( "url" ) );
     }
 
     public void testGetJiraUrlAndProjectName()
     {
         Map<String, String> map;
-        map = JiraHelper.getJiraUrlAndProjectName( "http://jira.codehaus.org/browse/DOXIA/" );
-        assertEquals( "http://jira.codehaus.org", map.get( "url" ) );
+        map = JiraHelper.getJiraUrlAndProjectName( "https://issues.apache.org/jira/browse/DOXIA/" );
+        assertEquals( "https://issues.apache.org/jira", map.get( "url" ) );
         assertEquals( "DOXIA", map.get( "project" ) );
 
-        map = JiraHelper.getJiraUrlAndProjectName( "http://jira.codehaus.org/browse/DOXIA" );
-        assertEquals( "http://jira.codehaus.org", map.get( "url" ) );
+        map = JiraHelper.getJiraUrlAndProjectName( "https://issues.apache.org/jira/browse/DOXIA" );
+        assertEquals( "https://issues.apache.org/jira", map.get( "url" ) );
         assertEquals( "DOXIA", map.get( "project" ) );
     }
 

--- a/maven-checkstyle-plugin/src/it/MCHECKSTYLE-214-basedir-resource/pom.xml
+++ b/maven-checkstyle-plugin/src/it/MCHECKSTYLE-214-basedir-resource/pom.xml
@@ -25,7 +25,7 @@
   <artifactId>MCHECKSTYLE-214</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <url>http://jira.codehaus.org/browse/MCHECKSTYLE-214</url>
+  <url>https://issues.apache.org/jira/browse/MCHECKSTYLE-214</url>
   
   <build>
     <resources>

--- a/maven-checkstyle-plugin/src/it/MCHECKSTYLE-70-multi-sourcefolder/pom.xml
+++ b/maven-checkstyle-plugin/src/it/MCHECKSTYLE-70-multi-sourcefolder/pom.xml
@@ -27,7 +27,7 @@
   <artifactId>multi-sourcefolder</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <url>http://jira.codehaus.org/browse/MCHECKSTYLE-70</url>
+  <url>https://issues.apache.org/jira/browse/MCHECKSTYLE-70</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven-checkstyle-plugin/src/main/java/org/apache/maven/plugin/checkstyle/CheckstyleReportGenerator.java
+++ b/maven-checkstyle-plugin/src/main/java/org/apache/maven/plugin/checkstyle/CheckstyleReportGenerator.java
@@ -450,7 +450,7 @@ public class CheckstyleReportGenerator
         // Check the severity. This helps to distinguish between
         // different configurations for the same rule, where each
         // configuration has a different severity, like JavadocMetod.
-        // See also http://jira.codehaus.org/browse/MCHECKSTYLE-41
+        // See also https://issues.apache.org/jira/browse/MCHECKSTYLE-41
         if ( expectedSeverity != null )
         {
             return expectedSeverity.equals( event.getSeverityLevel().getName() );

--- a/maven-compiler-plugin/src/it/MCOMPILER-228/pom.xml
+++ b/maven-compiler-plugin/src/it/MCOMPILER-228/pom.xml
@@ -28,7 +28,7 @@ under the License.
   <artifactId>mcompiler228</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <url>http://jira.codehaus.org/browse/MCOMPILER-228</url>    
+  <url>https://issues.apache.org/jira/browse/MCOMPILER-228</url>    
 
   <build>
     <plugins>

--- a/maven-compiler-plugin/src/it/groovy-project-with-new-plexus-compiler/pom.xml
+++ b/maven-compiler-plugin/src/it/groovy-project-with-new-plexus-compiler/pom.xml
@@ -35,7 +35,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
         <configuration>
           <compilerId>groovy-eclipse-compiler</compilerId>
           <verbose>true</verbose>
-          <!-- see https://jira.codehaus.org/browse/MCOMPILER-199 -->
+          <!-- see https://issues.apache.org/jira/browse/MCOMPILER-199 -->
           <!--includes>
             <include>**/*.groovy</include>
           </includes-->

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDepMgt.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDepMgt.java
@@ -44,7 +44,7 @@ import org.codehaus.plexus.util.StringUtils;
  * mismatches in your dependencyManagement section. In versions of maven prior
  * to 2.0.6, it was possible to inherit versions that didn't match your
  * dependencyManagement. See <a
- * href="http://jira.codehaus.org/browse/MNG-1577">MNG-1577</a> for more info.
+ * href="https://issues.apache.org/jira/browse/MNG-1577">MNG-1577</a> for more info.
  * This mojo is also useful for just detecting projects that override the
  * dependencyManagement directly. Set ignoreDirect to false to detect these
  * otherwise normal conditions.

--- a/maven-deploy-plugin/src/it/MDEPLOY-178_deployfile-with-embedded-pom/pom.xml
+++ b/maven-deploy-plugin/src/it/MDEPLOY-178_deployfile-with-embedded-pom/pom.xml
@@ -31,7 +31,7 @@ under the License.
     Test to verify that the pom inside the jar in used when deploying the file
   </description>
 
-  <url>https://jira.codehaus.org/browse/MDEPLOY-178</url>
+  <url>https://issues.apache.org/jira/browse/MDEPLOY-178</url>
 
   <build>
     <plugins>

--- a/maven-deploy-plugin/src/it/MDEPLOY-178_deployfile-with-embedded-pom/verify.groovy
+++ b/maven-deploy-plugin/src/it/MDEPLOY-178_deployfile-with-embedded-pom/verify.groovy
@@ -26,4 +26,4 @@ assert buildLog.exists()
 assert buildLog.text.contains( "[DEBUG] Using META-INF/maven/org.apache.maven.plugins.deploy.its/mdeploy178/pom.xml as pomFile" )
 
 def pomProject = new XmlSlurper().parse( deployedPom )
-assert "https://jira.codehaus.org/browse/MDEPLOY-178".equals( pomProject.url.text() )
+assert "https://issues.apache.org/jira/browse/MDEPLOY-178".equals( pomProject.url.text() )

--- a/maven-deploy-plugin/src/it/MDEPLOY-184_deployfile-with-javadoc-and-sources/path/to/pom.xml
+++ b/maven-deploy-plugin/src/it/MDEPLOY-184_deployfile-with-javadoc-and-sources/path/to/pom.xml
@@ -26,6 +26,6 @@ under the License.
   <artifactId>artifact-name</artifactId>
   <version>1.0</version>
 
-  <url>http://jira.codehaus.org/browse/MDEPLOY-184</url>
+  <url>https://issues.apache.org/jira/browse/MDEPLOY-184</url>
 
 </project>

--- a/maven-deploy-plugin/src/it/deploy-attached-sources/pom.xml
+++ b/maven-deploy-plugin/src/it/deploy-attached-sources/pom.xml
@@ -29,7 +29,7 @@ under the License.
 
   <name>deploy-attached-sources</name>
   <description>sample jar project with attached sources</description>
-  <url>http://jira.codehaus.org/browse/MDEPLOY-48</url>
+  <url>https://issues.apache.org/jira/browse/MDEPLOY-48</url>
 
   <distributionManagement>
     <repository>

--- a/maven-deploy-plugin/src/it/deploy-default-packaging/pom.xml
+++ b/maven-deploy-plugin/src/it/deploy-default-packaging/pom.xml
@@ -29,7 +29,7 @@ under the License.
 
   <name>deploy-attached-sources</name>
   <description>sample jar project with attached sources</description>
-  <url>http://jira.codehaus.org/browse/MDEPLOY-106</url>
+  <url>https://issues.apache.org/jira/browse/MDEPLOY-106</url>
 
   <distributionManagement>
     <repository>

--- a/maven-doap-plugin/src/it/MDOAP-38/pom.xml
+++ b/maven-doap-plugin/src/it/MDOAP-38/pom.xml
@@ -45,7 +45,7 @@ under the License.
   </scm>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MDOAP</url>
+    <url>https://issues.apache.org/jira/browse/MDOAP</url>
   </issueManagement>
   <licenses>
     <license>

--- a/maven-doap-plugin/src/it/basic/pom.xml
+++ b/maven-doap-plugin/src/it/basic/pom.xml
@@ -45,7 +45,7 @@ under the License.
   </scm>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MDOAP</url>
+    <url>https://issues.apache.org/jira/browse/MDOAP</url>
   </issueManagement>
   <licenses>
     <license>

--- a/maven-doap-plugin/src/it/doapfile/pom.xml
+++ b/maven-doap-plugin/src/it/doapfile/pom.xml
@@ -45,7 +45,7 @@ under the License.
   </scm>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MDOAP</url>
+    <url>https://issues.apache.org/jira/browse/MDOAP</url>
   </issueManagement>
   <licenses>
     <license>

--- a/maven-docck-plugin/src/it/basic/pom.xml
+++ b/maven-docck-plugin/src/it/basic/pom.xml
@@ -46,7 +46,7 @@ under the License.
   <issueManagement>
     <system>jira</system>
     <url>http://maven.apache.org/plugins/maven-docck-plugin/issue-tracking.html</url>
-    <!-- not http://issues.apache.org/jira/browse/MDOCCK because redirects to https rcausing "Could not generate DH keypair" failure with Java 6 -->
+    <!-- not https://issues.apache.org/jira/browse/MDOCCK because redirects to https rcausing "Could not generate DH keypair" failure with Java 6 -->
     <!-- See https://issues.apache.org/jira/browse/BUILDS-85 for details -->
   </issueManagement>
   <licenses>

--- a/maven-ear-plugin/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/maven-ear-plugin/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -412,7 +412,7 @@ public class EarMojo
             // should be identified by a unique id instead of the
             // the artifactId's only which means this
             // check can be removed.
-            // http://jira.codehaus.org/browse/MEAR-209
+            // https://issues.apache.org/jira/browse/MEAR-209
             checkModuleUniqueness();
 
             for ( EarModule module : getModules() )

--- a/maven-invoker-plugin/src/it/multiEnvVar/pom.xml
+++ b/maven-invoker-plugin/src/it/multiEnvVar/pom.xml
@@ -29,7 +29,7 @@ under the License.
   <name>Maven Environment Test</name>
   <description>Maven Invoker tests for environment variable setting</description>
 
-  <url>http://jira.codehaus.org/browse/MINVOKER-155</url>
+  <url>https://issues.apache.org/jira/browse/MINVOKER-155</url>
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven-invoker-plugin/src/it/settings-inherit/invoker.properties
+++ b/maven-invoker-plugin/src/it/settings-inherit/invoker.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# See https://jira.codehaus.org/browse/MNG-5224
+# See https://issues.apache.org/jira/browse/MNG-5224
 invoker.maven.version = 3.0-,3.0.4+

--- a/maven-invoker-plugin/src/it/settings-merge-multiexecutions/invoker.properties
+++ b/maven-invoker-plugin/src/it/settings-merge-multiexecutions/invoker.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# See https://jira.codehaus.org/browse/MNG-5224
+# See https://issues.apache.org/jira/browse/MNG-5224
 invoker.maven.version = 3.0-,3.0.4+

--- a/maven-invoker-plugin/src/it/settings-merge/invoker.properties
+++ b/maven-invoker-plugin/src/it/settings-merge/invoker.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# See https://jira.codehaus.org/browse/MNG-5224
+# See https://issues.apache.org/jira/browse/MNG-5224
 invoker.maven.version = 3.0-,3.0.4+

--- a/maven-jarsigner-plugin/src/it/resign/pom.xml
+++ b/maven-jarsigner-plugin/src/it/resign/pom.xml
@@ -27,7 +27,7 @@ under the License.
   <packaging>jar</packaging>
 
   <description>
-    Tests the signing of an already signed JAR (see http://jira.codehaus.org/browse/MJARSIGNER-33) that should be unsigned before re-signing.
+    Tests the signing of an already signed JAR (see https://issues.apache.org/jira/browse/MJARSIGNER-33) that should be unsigned before re-signing.
   </description>
 
   <properties>

--- a/maven-javadoc-plugin/.gitignore
+++ b/maven-javadoc-plugin/.gitignore
@@ -1,0 +1,1 @@
+javadoc-options-javadoc-resources.xml

--- a/maven-javadoc-plugin/src/it/MJAVADOC-365/pom.xml
+++ b/maven-javadoc-plugin/src/it/MJAVADOC-365/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>mjavadoc-369</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <url>https://jira.codehaus.org/browse/MJAVADOC-365</url>
+  <url>https://issues.apache.org/jira/browse/MJAVADOC-365</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven-pdf-plugin/src/test/resources/unit/pdf/src/site/apt/limitations.apt
+++ b/maven-pdf-plugin/src/test/resources/unit/pdf/src/site/apt/limitations.apt
@@ -32,7 +32,7 @@ Known Bugs and Limitations
 
 * Current limitations
 
-  * FML parsing doesn't work due to {{{http://jira.codehaus.org/browse/DOXIA-148}DOXIA-148}}.
+  * FML parsing doesn't work due to {{{https://issues.apache.org/jira/browse/DOXIA-148}DOXIA-148}}.
 
   * Xdoc tables don't work due to a bug in the xdoc parser.
 

--- a/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/PmdReportTest.java
+++ b/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/PmdReportTest.java
@@ -135,7 +135,7 @@ public class PmdReportTest
                       "src/test/resources/unit/default-configuration/default-configuration-plugin-config.xml" );
         PmdReport mojo = (PmdReport) lookupMojo( "pmd", testPom );
 
-        // Additional test case for MPMD-174 (http://jira.codehaus.org/browse/MPMD-174).
+        // Additional test case for MPMD-174 (https://issues.apache.org/jira/browse/MPMD-174).
         WireMockServer mockServer = new WireMockServer( 3456 );
         mockServer.start();
 

--- a/maven-project-info-reports-plugin/src/it/full-pom/pom.xml
+++ b/maven-project-info-reports-plugin/src/it/full-pom/pom.xml
@@ -108,7 +108,7 @@
   </scm>
   <issueManagement>
     <system>JIRA</system>
-    <url>http://jira.codehaus.org/browse/MPIR</url>
+    <url>https://issues.apache.org/jira/browse/MPIR</url>
   </issueManagement>
   <ciManagement>
     <system>Jenkins</system>

--- a/maven-repository-plugin/src/it/bundle-create-alt-pom/alternative-pom.xml
+++ b/maven-repository-plugin/src/it/bundle-create-alt-pom/alternative-pom.xml
@@ -47,7 +47,7 @@ under the License.
   
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MREPOSITORY</url>
+    <url>https://issues.apache.org/jira/browse/MREPOSITORY</url>
   </issueManagement>
   <licenses>
     <license>

--- a/maven-repository-plugin/src/it/bundle-create-no-scm/pom.xml
+++ b/maven-repository-plugin/src/it/bundle-create-no-scm/pom.xml
@@ -41,7 +41,7 @@ under the License.
 
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MREPOSITORY</url>
+    <url>https://issues.apache.org/jira/browse/MREPOSITORY</url>
   </issueManagement>
   <licenses>
     <license>

--- a/maven-repository-plugin/src/it/bundle-create/pom.xml
+++ b/maven-repository-plugin/src/it/bundle-create/pom.xml
@@ -47,7 +47,7 @@ under the License.
   
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MREPOSITORY</url>
+    <url>https://issues.apache.org/jira/browse/MREPOSITORY</url>
   </issueManagement>
   <licenses>
     <license>

--- a/maven-shade-plugin/src/it/mini-jar-malformed-dependencies/pom.xml
+++ b/maven-shade-plugin/src/it/mini-jar-malformed-dependencies/pom.xml
@@ -29,7 +29,7 @@ under the License.
 
   <dependencies>  
     <!-- dependencies with "malformed classes" that break asm's ClassReader -->
-    <!-- see also http://jira.codehaus.org/browse/MANIMALSNIFFER-9 -->
+    <!-- see also https://issues.apache.org/jira/browse/MANIMALSNIFFER-9 -->
     <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>

--- a/maven-site-plugin/src/it/doxia-formats/src/site/markdown/markdown.md
+++ b/maven-site-plugin/src/it/doxia-formats/src/site/markdown/markdown.md
@@ -22,7 +22,7 @@ Markdown Format works
 ---------------
 
 But 'quotes' and "double quotes" were stripped from HTML result with DOXIA 1.3:
-see [DOXIA-473](https://jira.codehaus.org/browse/DOXIA-473).
+see [DOXIA-473](https://issues.apache.org/jira/browse/DOXIA-473).
 
 <!-- MACRO{toc|fromDepth=1|toDepth=2} -->
 

--- a/maven-site-plugin/src/it/doxia-formats/src/site/markdown/markdown2.markdown
+++ b/maven-site-plugin/src/it/doxia-formats/src/site/markdown/markdown2.markdown
@@ -22,7 +22,7 @@ Markdown Format works
 ---------------
 
 But 'quotes' and "double quotes" were stripped from HTML result with DOXIA 1.3:
-see [DOXIA-473](https://jira.codehaus.org/browse/DOXIA-473).
+see [DOXIA-473](https://issues.apache.org/jira/browse/DOXIA-473).
 
 <!-- MACRO{toc|fromDepth=1|toDepth=2} -->
 

--- a/maven-site-plugin/src/it/reportConfig/pom.xml
+++ b/maven-site-plugin/src/it/reportConfig/pom.xml
@@ -29,7 +29,7 @@ under the License.
 
   <name>MSITE-516 Report Configuration IT</name>
   <description>
-    http://jira.codehaus.org/browse/MSITE-516
+    https://issues.apache.org/jira/browse/MSITE-516
     Checks that report configuration is inherited from build.pluginManagement: see MSHARED-338.
   </description>
   <url>http://maven.apache.org</url>

--- a/maven-stage-plugin/src/test/staging-repository/org/apache/maven/maven/2.0.6/maven-2.0.6.pom
+++ b/maven-stage-plugin/src/test/staging-repository/org/apache/maven/maven/2.0.6/maven-2.0.6.pom
@@ -33,7 +33,7 @@ under the License.
   <url>http://maven.apache.org</url>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MNG</url>
+    <url>https://issues.apache.org/jira/browse/MNG</url>
   </issueManagement>
   <inceptionYear>2001</inceptionYear>
   <mailingLists>

--- a/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven-script/2.0.3/maven-script-2.0.3.pom
+++ b/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven-script/2.0.3/maven-script-2.0.3.pom
@@ -13,7 +13,7 @@
   <url>http://maven.apache.org/maven-script</url>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MNG</url>
+    <url>https://issues.apache.org/jira/browse/MNG</url>
   </issueManagement>
   <ciManagement>
     <system>continuum</system>

--- a/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.1/maven-2.0.1.pom
+++ b/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.1/maven-2.0.1.pom
@@ -9,7 +9,7 @@
   <url>http://maven.apache.org/</url>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MNG</url>
+    <url>https://issues.apache.org/jira/browse/MNG</url>
   </issueManagement>
   <ciManagement>
     <system>continuum</system>

--- a/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.2/maven-2.0.2.pom
+++ b/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.2/maven-2.0.2.pom
@@ -9,7 +9,7 @@
   <url>http://maven.apache.org/</url>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MNG</url>
+    <url>https://issues.apache.org/jira/browse/MNG</url>
   </issueManagement>
   <ciManagement>
     <system>continuum</system>

--- a/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.3/maven-2.0.3.pom
+++ b/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.3/maven-2.0.3.pom
@@ -9,7 +9,7 @@
   <url>http://maven.apache.org</url>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MNG</url>
+    <url>https://issues.apache.org/jira/browse/MNG</url>
   </issueManagement>
   <ciManagement>
     <system>continuum</system>

--- a/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.4/maven-2.0.4.pom
+++ b/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.4/maven-2.0.4.pom
@@ -9,7 +9,7 @@
   <url>http://maven.apache.org</url>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MNG</url>
+    <url>https://issues.apache.org/jira/browse/MNG</url>
   </issueManagement>
   <ciManagement>
     <system>continuum</system>

--- a/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.5/maven-2.0.5.pom
+++ b/maven-stage-plugin/src/test/target-repository/org/apache/maven/maven/2.0.5/maven-2.0.5.pom
@@ -14,7 +14,7 @@
   <url>http://maven.apache.org</url>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MNG</url>
+    <url>https://issues.apache.org/jira/browse/MNG</url>
   </issueManagement>
   <inceptionYear>2001</inceptionYear>
   <mailingLists>

--- a/maven-stage-plugin/src/test/target-repository/org/apache/maven/reporting/maven-reporting/2.0.3/maven-reporting-2.0.3.pom
+++ b/maven-stage-plugin/src/test/target-repository/org/apache/maven/reporting/maven-reporting/2.0.3/maven-reporting-2.0.3.pom
@@ -14,7 +14,7 @@
   <url>http://maven.apache.org/maven-reporting</url>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.codehaus.org/browse/MNG</url>
+    <url>https://issues.apache.org/jira/browse/MNG</url>
   </issueManagement>
   <ciManagement>
     <system>continuum</system>

--- a/maven-toolchains-plugin/src/it/setup-custom-toolchain/pom.xml
+++ b/maven-toolchains-plugin/src/it/setup-custom-toolchain/pom.xml
@@ -132,7 +132,7 @@ under the License.
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-plugin-plugin</artifactId>
             <configuration>
-              <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
+              <!-- see https://issues.apache.org/jira/browse/MNG-5346 -->
               <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
             </configuration>
             <executions>

--- a/maven-toolchains-plugin/src/it/setup-custom-toolchain/src/main/java/org/apache/maven/plugins/toolchains/its/custom/CustomToolchainFactory.java
+++ b/maven-toolchains-plugin/src/it/setup-custom-toolchain/src/main/java/org/apache/maven/plugins/toolchains/its/custom/CustomToolchainFactory.java
@@ -132,7 +132,7 @@ public class CustomToolchainFactory
      * 
      * @param model the toolchain model as read from XML
      * @return the properties defined in the <code>provides</code> element
-     * @see <a href="http://jira.codehaus.org/browse/MNG-5718">MNG-5718</a> 
+     * @see <a href="https://issues.apache.org/jira/browse/MNG-5718">MNG-5718</a> 
      */
     protected Properties getProvidesProperties( ToolchainModel model )
     {

--- a/maven-war-plugin/src/it/MWAR-240/pom.xml
+++ b/maven-war-plugin/src/it/MWAR-240/pom.xml
@@ -26,7 +26,7 @@
   <version>1.0</version>
   <name>MWAR-240 Test case</name>
   <packaging>war</packaging>
-  <description>Test project for reproducing an issue with classes packaging: http://jira.codehaus.org/browse/MWAR-240</description>
+  <description>Test project for reproducing an issue with classes packaging: https://issues.apache.org/jira/browse/MWAR-240</description>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Looking though several plugins (http://maven.apache.org/plugins/maven-install-plugin/issue-tracking.html) and discovered the currently published url for issue tracking is pointing to codehaus.

This pull requests corrects all the links to they point to valid end points.