### PR TITLE
getProjectModules: IllegalStateException

### DIFF
--- a/maven-assembly-plugin/src/main/java/org/apache/maven/plugins/assembly/utils/ProjectUtils.java
+++ b/maven-assembly-plugin/src/main/java/org/apache/maven/plugins/assembly/utils/ProjectUtils.java
@@ -130,6 +130,9 @@ public final class ProjectUtils
                         // increment the change counter, to show that we
                         // verified a new module on this pass.
                         changed++;
+                        
+                        // We need to move on to the next candidate since this one was just verified
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
In my project, we have multiple modules, some of which also contain other modules.
When building one specific module (which itself had child modules) from the root pom file, the build would fail when maven-assembly-plugin threw an IllegalStateException, but building from the module's pom.xml file directly, the build succeeded.

I narrowed this down to the candidateIterator being set to null after .remove() is called, and that iterator not being updated to the next item before using it as a candidate for other projects.

This change ensures that after removing the item from the iterator, that we move to the next item before doing anymore comparisons.

This is the stacktrace from the maven-assembly-plugin failure:
```

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.5.5:single (default) on project Flatternscore_by_tenantid_daily: Execution def
ault of goal org.apache.maven.plugins:maven-assembly-plugin:2.5.5:single failed. IllegalStateException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.5.5:single (default) on projec
t Flatternscore_by_tenantid_daily: Execution default of goal org.apache.maven.plugins:maven-assembly-plugin:2.5.5:single failed.
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:224)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:862)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:286)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:197)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default of goal org.apache.maven.plugins:maven-assembly-plugin:2.5.5:single failed.
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:145)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
        ... 20 more
Caused by: java.lang.IllegalStateException
        at java.util.LinkedHashMap$LinkedHashIterator.remove(LinkedHashMap.java:722)
        at org.apache.maven.plugin.assembly.utils.ProjectUtils.getProjectModules(ProjectUtils.java:128)
        at org.apache.maven.plugin.assembly.archive.phase.ModuleSetAssemblyPhase.getModuleProjects(ModuleSetAssemblyPhase.java:566)
        at org.apache.maven.plugin.assembly.archive.phase.ModuleSetAssemblyPhase$1.accept(ModuleSetAssemblyPhase.java:134)
        at org.apache.maven.plugin.assembly.model.Assemblies.forEachModuleSet(Assemblies.java:40)
        at org.apache.maven.plugin.assembly.archive.phase.ModuleSetAssemblyPhase.execute(ModuleSetAssemblyPhase.java:126)
        at org.apache.maven.plugin.assembly.archive.DefaultAssemblyArchiver.createArchive(DefaultAssemblyArchiver.java:178)
        at org.apache.maven.plugin.assembly.mojos.AbstractAssemblyMojo.execute(AbstractAssemblyMojo.java:484)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
        ... 21 more
```