### PR TITLE
MWAR-257 Remove deprecation of dependentWarExcludes, since there is no alternative on global level

### DIFF
--- a/maven-war-plugin/src/it/overlay-keeps-contextxml/invoker.properties
+++ b/maven-war-plugin/src/it/overlay-keeps-contextxml/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=clean install

--- a/maven-war-plugin/src/it/overlay-keeps-contextxml/pom.xml
+++ b/maven-war-plugin/src/it/overlay-keeps-contextxml/pom.xml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+         xsi:schemaLocation='http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd'
+         xmlns='http://maven.apache.org/POM/4.0.0'>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>debug.war</groupId>
+  <artifactId>overlay-keeps-contextxml</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>test that default overlay keeps META-INF/context.xml</name>
+  <url>http://maven.apache.org</url>
+  <modules>
+    <module>war1-with-contextxml</module>
+    <module>war2-result</module>
+  </modules>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/maven-war-plugin/src/it/overlay-keeps-contextxml/verify.bsh
+++ b/maven-war-plugin/src/it/overlay-keeps-contextxml/verify.bsh
@@ -1,0 +1,31 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+
+    File testFile = new File( basedir, "war2-result/target/war2-result-1.0-SNAPSHOT/META-INF/context.xml");
+    if ( !testFile.exists() )
+    {
+        System.err.println( "war1 META-INF/context.xml lost in overlay process" );
+        return false;
+    }
+

--- a/maven-war-plugin/src/it/overlay-keeps-contextxml/war1-with-contextxml/pom.xml
+++ b/maven-war-plugin/src/it/overlay-keeps-contextxml/war1-with-contextxml/pom.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>debug.war</groupId>
+    <artifactId>overlay-keeps-contextxml</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>  
+  <artifactId>war1-with-contextxml</artifactId>
+  <packaging>war</packaging>
+
+</project>

--- a/maven-war-plugin/src/it/overlay-keeps-contextxml/war1-with-contextxml/src/main/webapp/META-INF/context.xml
+++ b/maven-war-plugin/src/it/overlay-keeps-contextxml/war1-with-contextxml/src/main/webapp/META-INF/context.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/maven-war-plugin/src/it/overlay-keeps-contextxml/war1-with-contextxml/src/main/webapp/WEB-INF/web.xml
+++ b/maven-war-plugin/src/it/overlay-keeps-contextxml/war1-with-contextxml/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+         version="2.4">
+
+</web-app>

--- a/maven-war-plugin/src/it/overlay-keeps-contextxml/war2-result/pom.xml
+++ b/maven-war-plugin/src/it/overlay-keeps-contextxml/war2-result/pom.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>debug.war</groupId>
+		<artifactId>overlay-excludes</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>war2-result</artifactId>
+	<packaging>war</packaging>
+	<dependencies>
+		<!-- War Overlay -->
+		<dependency>
+			<groupId>debug.war</groupId>
+			<artifactId>war1-with-contextxml</artifactId>
+			<version>1.0-SNAPSHOT</version>
+			<type>war</type>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-war-plugin/src/it/overlay-keeps-contextxml/war2-result/src/main/webapp/WEB-INF/web.xml
+++ b/maven-war-plugin/src/it/overlay-keeps-contextxml/war2-result/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+         version="2.4">
+
+</web-app>

--- a/maven-war-plugin/src/main/java/org/apache/maven/plugins/war/AbstractWarMojo.java
+++ b/maven-war-plugin/src/main/java/org/apache/maven/plugins/war/AbstractWarMojo.java
@@ -243,6 +243,22 @@ public abstract class AbstractWarMojo
     private String warSourceExcludes;
 
     /**
+     * The comma separated list of tokens to include when doing a WAR overlay. Default is 
+     * {@link org.apache.maven.plugins.war.Overlay#DEFAULT_INCLUDES}
+     *
+     */
+    @Parameter
+    private String dependentWarIncludes = StringUtils.join( Overlay.DEFAULT_INCLUDES, "," );
+
+    /**
+     * The comma separated list of tokens to exclude when doing a WAR overlay. Default is 
+     * {@link org.apache.maven.plugins.war.Overlay#DEFAULT_EXCLUDES}
+     *
+     */
+    @Parameter
+    private String dependentWarExcludes = StringUtils.join( Overlay.DEFAULT_EXCLUDES, "," );
+
+    /**
      * The overlays to apply. Each &lt;overlay&gt; element may contain:
      * <ul>
      * <li>id (defaults to <tt>currentBuild</tt>)</li>
@@ -320,7 +336,7 @@ public abstract class AbstractWarMojo
 
     /**
      * Stop searching endToken at the end of line
-     *
+     * 
      * @since 2.4
      */
     @Parameter( defaultValue = "false" )
@@ -328,7 +344,7 @@ public abstract class AbstractWarMojo
 
     /**
      * use jvmChmod rather that cli chmod and forking process
-     *
+     * 
      * @since 2.4
      */
     @Parameter( defaultValue = "true" )
@@ -392,6 +408,26 @@ public abstract class AbstractWarMojo
     }
 
     /**
+     * Returns a string array of the excludes to be used when adding dependent WAR as an overlay onto this WAR.
+     *
+     * @return an array of tokens to exclude
+     */
+    protected String[] getDependentWarExcludes()
+    {
+        return StringUtils.split( StringUtils.defaultString( dependentWarExcludes ), "," );
+    }
+
+    /**
+     * Returns a string array of the includes to be used when adding dependent WARs as an overlay onto this WAR.
+     *
+     * @return an array of tokens to include
+     */
+    protected String[] getDependentWarIncludes()
+    {
+        return StringUtils.split( StringUtils.defaultString( dependentWarIncludes ), "," );
+    }
+
+    /**
      * @param webapplicationDirectory The web application directory.
      * @throws MojoExecutionException In case of failure.
      * @throws MojoFailureException In case of failure.
@@ -442,7 +478,8 @@ public abstract class AbstractWarMojo
         getLog().info( "Assembling webapp [" + mavenProject.getArtifactId() + "] in [" + webapplicationDirectory + "]" );
 
         final OverlayManager overlayManager =
-            new OverlayManager( overlays, mavenProject, currentProjectOverlay );
+            new OverlayManager( overlays, mavenProject, getDependentWarIncludes(), getDependentWarExcludes(),
+                                currentProjectOverlay );
         final List<WarPackagingTask> packagingTasks = getPackagingTasks( overlayManager );
         // CHECKSTYLE_ON: LineLength
         List<FileUtils.FilterWrapper> defaultFilterWrappers;
@@ -500,8 +537,9 @@ public abstract class AbstractWarMojo
     }
 
     /**
-     * Returns a <tt>List</tt> of the {@link org.apache.maven.plugins.war.packaging.WarPackagingTask}
-     * instances to invoke to perform the packaging.
+     * Returns a <tt>List</tt> of the {@link org.apache.maven.plugins.war.packaging.WarPackagingTask} 
+     * instances to invoke
+     * to perform the packaging.
      *
      * @param overlayManager the overlay manager
      * @return the list of packaging tasks

--- a/maven-war-plugin/src/main/java/org/apache/maven/plugins/war/overlay/DefaultOverlay.java
+++ b/maven-war-plugin/src/main/java/org/apache/maven/plugins/war/overlay/DefaultOverlay.java
@@ -46,4 +46,18 @@ public class DefaultOverlay
         setArtifact( a );
         setType( a.getType() );
     }
+
+    /**
+     * Creates an overlay for the specified artifact.
+     *
+     * @param a the artifact
+     * @param includes the includes to use
+     * @param excludes the excludes to use
+     */
+    public DefaultOverlay( Artifact a, String[] includes, String[] excludes )
+    {
+        this( a );
+        setIncludes( includes );
+        setExcludes( excludes );
+    }
 }

--- a/maven-war-plugin/src/main/java/org/apache/maven/plugins/war/overlay/OverlayManager.java
+++ b/maven-war-plugin/src/main/java/org/apache/maven/plugins/war/overlay/OverlayManager.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.war.overlay;
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
@@ -51,10 +52,13 @@ public class OverlayManager
      *
      * @param overlays the overlays
      * @param project the maven project
+     * @param defaultIncludes the default includes to use
+     * @param defaultExcludes the default excludes to use
      * @param currentProjectOverlay the overlay for the current project
      * @throws InvalidOverlayConfigurationException if the config is invalid
      */
-    public OverlayManager( List<Overlay> overlays, MavenProject project, Overlay currentProjectOverlay )
+    public OverlayManager( List<Overlay> overlays, MavenProject project, String[] defaultIncludes,
+                           String[] defaultExcludes, Overlay currentProjectOverlay )
         throws InvalidOverlayConfigurationException
     {
         this.overlays = new ArrayList<Overlay>();
@@ -67,7 +71,7 @@ public class OverlayManager
         this.artifactsOverlays = getOverlaysAsArtifacts();
 
         // Initialize
-        initialize( currentProjectOverlay );
+        initialize( defaultIncludes, defaultExcludes, currentProjectOverlay );
 
     }
 
@@ -99,11 +103,13 @@ public class OverlayManager
 
     /**
      * Initializes the manager and validates the overlays configuration.
-     * @param currentProjectOverlay the overlay for the current project
      *
+     * @param defaultIncludes the default includes to use
+     * @param defaultExcludes the default excludes to use
+     * @param currentProjectOverlay the overlay for the current project
      * @throws InvalidOverlayConfigurationException if the configuration is invalid
      */
-    void initialize( Overlay currentProjectOverlay )
+    void initialize( String[] defaultIncludes, String[] defaultExcludes, Overlay currentProjectOverlay )
         throws InvalidOverlayConfigurationException
     {
 
@@ -124,6 +130,13 @@ public class OverlayManager
                 overlay = currentProjectOverlay;
                 it.set( overlay );
             }
+            // default includes/excludes - only if the overlay uses the default settings
+            if ( Arrays.equals( Overlay.DEFAULT_INCLUDES, overlay.getIncludes() )
+                && Arrays.equals( Overlay.DEFAULT_EXCLUDES, overlay.getExcludes() ) )
+            {
+                overlay.setIncludes( defaultIncludes );
+                overlay.setExcludes( defaultExcludes );
+            }
 
             final Artifact artifact = getAssociatedArtifact( overlay );
             if ( artifact != null )
@@ -140,7 +153,7 @@ public class OverlayManager
             {
                 // Add a default overlay for the given artifact which will be applied after
                 // the ones that have been configured
-                overlays.add( new DefaultOverlay( artifact ) );
+                overlays.add( new DefaultOverlay( artifact, defaultIncludes, defaultExcludes ) );
             }
         }
 
@@ -184,7 +197,6 @@ public class OverlayManager
         }
 
         // maybe its a project dependencies zip or an other type
-        @SuppressWarnings( "unchecked" )
         Set<Artifact> projectArtifacts = this.project.getDependencyArtifacts();
         if ( projectArtifacts != null )
         {
@@ -227,7 +239,6 @@ public class OverlayManager
     private List<Artifact> getOverlaysAsArtifacts()
     {
         ScopeArtifactFilter filter = new ScopeArtifactFilter( Artifact.SCOPE_RUNTIME );
-        @SuppressWarnings( "unchecked" )
         final Set<Artifact> artifacts = project.getArtifacts();
 
         final List<Artifact> result = new ArrayList<Artifact>();

--- a/maven-war-plugin/src/site/apt/overlays.apt.vm
+++ b/maven-war-plugin/src/site/apt/overlays.apt.vm
@@ -293,7 +293,43 @@ documentedprojectdependency-1.0-SNAPSHOT.war
 
 * Overlay global settings
 
-   The following settings can be specified globally and modify the way all overlays are applied:
+   The following settings can be specified globally and modify the way all overlays are applied.
+
+   * <<dependentWarIncludes>> - sets the default includes to apply to all overlays. Any overlay that
+    has no specific <<<includes>>> element will inherit this setting by default.
+
++-----------------+
+    ...
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <dependentWarIncludes>**/IncludeME,**/images</dependentWarIncludes>
+        </configuration>
+       </plugin>
+    </plugins>
+    ...
++-----------------+
+
+   * <<dependentWarExcludes>> - sets the default excludes to apply to all overlays. Any overlay that
+    has no specific <<<excludes>>> element will inherit this setting by default.
+
++-----------------+
+    ...
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <dependentWarExcludes>WEB-INF/web.xml,index.*</dependentWarExcludes>
+        </configuration>
+       </plugin>
+    </plugins>
+    ...
++-----------------+
 
    * <<workDirectory>> - sets the directory where overlays will be temporarily extracted.
 

--- a/maven-war-plugin/src/site/fml/faq.fml.vm
+++ b/maven-war-plugin/src/site/fml/faq.fml.vm
@@ -55,6 +55,13 @@ under the License.
        <p>Give it a "provided" scope.</p>
      </answer>
    </faq>
+   <faq id="dependentwarexclude">
+     <question>What's the difference between using dependentWarExclude and provided scope?</question>
+     <answer>
+       <p><code>dependentWarExclude</code> is used in <a href="overlays.html">overlays</a> for excluding dependent
+       WAR files from the assembled webapp.</p>
+     </answer>
+   </faq>
    <faq id="webresourcesexclude">
      <question>How do I exclude files in my web resources?</question>
      <answer>
@@ -66,7 +73,7 @@ under the License.
    <faq id="waroverlaysexclude">
      <question>How do I exclude files when doing overlays?</question>
      <answer>
-       <p>Use the <code>excludes</code> parameter in <code>overlay</code> to identify the tokens to exclude.</p>
+       <p>Use the <code>dependentWarExcludes</code> parameter to identify the tokens to exclude.</p>
      </answer>
    </faq>
    <faq id="configurationdoc">

--- a/maven-war-plugin/src/test/java/org/apache/maven/plugins/war/WarExplodedMojoTest.java
+++ b/maven-war-plugin/src/test/java/org/apache/maven/plugins/war/WarExplodedMojoTest.java
@@ -40,7 +40,6 @@ import org.codehaus.plexus.util.FileUtils;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Locale;
 
 public class WarExplodedMojoTest
@@ -874,13 +873,9 @@ public class WarExplodedMojoTest
         // configure mojo
         project.addArtifact( includeexcludeWarArtifact );
         this.configureMojo( mojo, new LinkedList<String>(), classesDir, webAppSource, webAppDirectory, project );
+        setVariableValueToObject( mojo, "dependentWarIncludes", "**/*Include.jsp,**/*.xml" );
+        setVariableValueToObject( mojo, "dependentWarExcludes", "**/*Exclude*,**/MANIFEST.MF" );
         setVariableValueToObject( mojo, "workDirectory", workDirectory );
-        Overlay overlay = new Overlay( "wartests", "war-include-exclude" );
-        overlay.setIncludes( "**/*Include.jsp,**/*.xml" );
-        overlay.setExcludes( "**/*Exclude*,META-INF/MANIFEST.MF" );
-        List<Overlay> overlays = new LinkedList<Overlay>();
-        overlays.add( overlay );
-        setVariableValueToObject( mojo, "overlays", overlays );
         mojo.execute();
 
         // validate operation

--- a/maven-war-plugin/src/test/java/org/apache/maven/plugins/war/overlay/OverlayManagerTest.java
+++ b/maven-war-plugin/src/test/java/org/apache/maven/plugins/war/overlay/OverlayManagerTest.java
@@ -19,6 +19,9 @@ package org.apache.maven.plugins.war.overlay;
  * under the License.
  */
 
+import static org.apache.maven.plugins.war.Overlay.DEFAULT_INCLUDES;
+import static org.apache.maven.plugins.war.Overlay.DEFAULT_EXCLUDES;
+
 import org.apache.maven.plugin.testing.stubs.ArtifactStub;
 import org.apache.maven.plugins.war.Overlay;
 import org.apache.maven.plugins.war.overlay.DefaultOverlay;
@@ -39,10 +42,6 @@ public class OverlayManagerTest
     extends PlexusTestCase
 {
 
-    public static final String DEFAULT_INCLUDES = "**/**";
-
-    public static final String DEFAULT_EXCLUDES = "META-INF/MANIFEST.MF";
-
 
     public void testEmptyProject()
         throws Exception
@@ -52,7 +51,8 @@ public class OverlayManagerTest
         try
         {
             final Overlay currentProjectOVerlay = Overlay.createInstance();
-            OverlayManager manager = new OverlayManager( overlays, project, currentProjectOVerlay );
+            OverlayManager manager = new OverlayManager( overlays, project, DEFAULT_INCLUDES, DEFAULT_EXCLUDES,
+                                                         currentProjectOVerlay );
             assertNotNull( manager.getOverlays() );
             assertEquals( 1, manager.getOverlays().size() );
             assertEquals( currentProjectOVerlay, manager.getOverlays().get( 0 ) );
@@ -77,7 +77,8 @@ public class OverlayManagerTest
         try
         {
             final Overlay overlay = currentProjectOverlay;
-            OverlayManager manager = new OverlayManager( overlays, project, overlay );
+            OverlayManager manager = new OverlayManager( overlays, project, DEFAULT_INCLUDES, DEFAULT_EXCLUDES,
+                                                         overlay );
             assertNotNull( manager.getOverlays() );
             assertEquals( 2, manager.getOverlays().size() );
             assertEquals( overlay, manager.getOverlays().get( 0 ) );
@@ -104,7 +105,8 @@ public class OverlayManagerTest
         try
         {
             final Overlay currentProjectOverlay = Overlay.createInstance();
-            OverlayManager manager = new OverlayManager( overlays, project, currentProjectOverlay );
+            OverlayManager manager = new OverlayManager( overlays, project, DEFAULT_INCLUDES, DEFAULT_EXCLUDES,
+                                                         currentProjectOverlay );
             assertNotNull( manager.getOverlays() );
             assertEquals( 2, manager.getOverlays().size() );
             assertEquals( Overlay.createInstance(), manager.getOverlays().get( 0 ) );
@@ -131,7 +133,7 @@ public class OverlayManagerTest
         try
         {
             final Overlay currentProjectOVerlay = Overlay.createInstance();
-            new OverlayManager( overlays, project, currentProjectOVerlay );
+            new OverlayManager( overlays, project, DEFAULT_INCLUDES, DEFAULT_EXCLUDES, currentProjectOVerlay );
             fail( "Should have failed to validate an unknown overlay" );
         }
         catch ( InvalidOverlayConfigurationException e )
@@ -157,7 +159,8 @@ public class OverlayManagerTest
 
         try
         {
-            OverlayManager manager = new OverlayManager( overlays, project, currentProjectOverlay );
+            OverlayManager manager = new OverlayManager( overlays, project, DEFAULT_INCLUDES, DEFAULT_EXCLUDES,
+                                                         currentProjectOverlay );
             assertNotNull( manager.getOverlays() );
             assertEquals( 3, manager.getOverlays().size() );
             assertEquals( overlays.get( 0 ), manager.getOverlays().get( 0 ) );
@@ -190,7 +193,8 @@ public class OverlayManagerTest
         try
         {
             final Overlay currentProjectOverlay = Overlay.createInstance();
-            OverlayManager manager = new OverlayManager( overlays, project, currentProjectOverlay );
+            OverlayManager manager = new OverlayManager( overlays, project, DEFAULT_INCLUDES, DEFAULT_EXCLUDES,
+                                                         currentProjectOverlay );
             assertNotNull( manager.getOverlays() );
             assertEquals( 3, manager.getOverlays().size() );
             assertEquals( currentProjectOverlay, manager.getOverlays().get( 0 ) );


### PR DESCRIPTION
Revert "[MWAR-367] Overlay removes /META-INF/context.xml"

This reverts commit cb254e434a40b7ff58c936abbb3f823029a0e466.