### PR TITLE
[MCOMPILER-290] Fix invalid comment out in the examples of module-info documentation

### DIFF
--- a/maven-compiler-plugin/src/site/apt/examples/module-info.apt.vm
+++ b/maven-compiler-plugin/src/site/apt/examples/module-info.apt.vm
@@ -66,7 +66,7 @@ Older projects with module-info
             <goals>
               <goal>compile</goal>
             </goals>
-            <!-- recompile everything for target VM except the module-info.java
+            <!-- recompile everything for target VM except the module-info.java -->
             <configuration>
               <excludes>
                 <exclude>module-info.java</exclude>
@@ -119,7 +119,7 @@ Older projects with module-info
             <goals>
               <goal>compile</goal>
             </goals>
-            <!-- recompile everything for target VM except the module-info.java
+            <!-- recompile everything for target VM except the module-info.java -->
             <configuration>
               <excludes>
                 <exclude>module-info.java</exclude>


### PR DESCRIPTION
* Add missing `-->` in module-info.apt.vm.