### PR TITLE
Updated dependencies

### DIFF
--- a/maven-linkcheck-plugin/pom.xml
+++ b/maven-linkcheck-plugin/pom.xml
@@ -107,7 +107,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-invoker</artifactId>
-      <version>2.1.1</version>
+      <version>3.0.0</version>
     </dependency>
 
     <!-- doxia -->

--- a/maven-linkcheck-plugin/src/main/java/org/apache/maven/plugins/linkcheck/SiteInvoker.java
+++ b/maven-linkcheck-plugin/src/main/java/org/apache/maven/plugins/linkcheck/SiteInvoker.java
@@ -189,7 +189,7 @@ public class SiteInvoker
         InvocationRequest request = new DefaultInvocationRequest();
         request.setLocalRepositoryDirectory( localRepoDir );
         // request.setUserSettingsFile( settingsFile );
-        request.setInteractive( false );
+        request.setBatchMode( true );
         request.setShowErrors( getLog().isErrorEnabled() );
         request.setDebug( getLog().isDebugEnabled() );
         // request.setShowVersion( false );


### PR DESCRIPTION
Key upgrade was the maven-invoker-plugin which prevented execution on
current version of Maven due to change from mvn.bat to mvn.cmd

Code change to accomodate the API change.

Fixes https://issues.apache.org/jira/browse/MLINKCHECK-29