### PR TITLE
MWAR-405  Workaround XStream incompatibility with Java9

### DIFF
--- a/maven-war-plugin/src/main/java/org/apache/maven/plugins/war/util/WebappStructureSerializer.java
+++ b/maven-war-plugin/src/main/java/org/apache/maven/plugins/war/util/WebappStructureSerializer.java
@@ -20,7 +20,16 @@ package org.apache.maven.plugins.war.util;
  */
 
 import com.thoughtworks.xstream.XStream;
+import static com.thoughtworks.xstream.XStream.PRIORITY_NORMAL;
+import static com.thoughtworks.xstream.XStream.PRIORITY_VERY_LOW;
+import com.thoughtworks.xstream.converters.basic.IntConverter;
+import com.thoughtworks.xstream.converters.basic.StringConverter;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
+import com.thoughtworks.xstream.converters.collections.MapConverter;
+import com.thoughtworks.xstream.converters.reflection.ReflectionConverter;
+import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
 import com.thoughtworks.xstream.io.xml.DomDriver;
+import com.thoughtworks.xstream.mapper.Mapper;
 import org.apache.maven.model.Dependency;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
@@ -44,8 +53,21 @@ public class WebappStructureSerializer
 
     static
     {
-        XSTREAM = new XStream( new DomDriver() );
-
+        XSTREAM = new XStream( new DomDriver() )
+        {
+            @Override
+            protected void setupConverters()
+            {
+                Mapper mapper = getMapper();
+                ReflectionProvider reflectionProvider = getReflectionProvider();
+                registerConverter(
+                    new ReflectionConverter( mapper, reflectionProvider ), PRIORITY_VERY_LOW );
+                registerConverter( new StringConverter(), PRIORITY_NORMAL );
+                registerConverter( new IntConverter(), PRIORITY_NORMAL );
+                registerConverter( new CollectionConverter( mapper ), PRIORITY_NORMAL );
+                registerConverter( new MapConverter( mapper ), PRIORITY_NORMAL );
+            }
+        };
         // Register aliases
         XSTREAM.alias( "webapp-structure", WebappStructure.class );
         XSTREAM.alias( "path-set", PathSet.class );


### PR DESCRIPTION
This is a proof-of-concept implementation of a possible way to word-around the actual incompatibility of xstreams default converters with java9.
As the maven-war-plugin does not need all of the converters (like TreeMapConverter which is the primary cause of the issue) we can just register only the needed ones and bypass the java9 issue

see

    Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Comparator java.util.TreeMap.comparator accessible: module java.base does not "opens java.util" to unnamed module
    Happens while initializing org.apache.maven.plugins.war.util.WebappStructureSerializer

at
https://cwiki.apache.org/confluence/display/MAVEN/Java+9+-+Jigsaw

this PR is just a proof-of-concept, there is an email thread on the dev list. If the idea is accepted I will submit a JIRA and official PR (some code cleanup is needed at least)