### PR TITLE
Upgrade to Plexus IO 3.0.0

### DIFF
--- a/maven-assembly-plugin/pom.xml
+++ b/maven-assembly-plugin/pom.xml
@@ -156,7 +156,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-io</artifactId>
-      <version>2.7.1</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
See MASSEMBLY-859

PR #116 should be merged first as plexus io 3.0.0 requires Java 7