### PR TITLE
Adds "failOnWarning" tests

### DIFF
--- a/maven-compiler-plugin/src/it/fail-on-warning/invoker.properties
+++ b/maven-compiler-plugin/src/it/fail-on-warning/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean compile
+invoker.buildResult = failure
+invoker.java.version = 1.6+

--- a/maven-compiler-plugin/src/it/fail-on-warning/pom.xml
+++ b/maven-compiler-plugin/src/it/fail-on-warning/pom.xml
@@ -1,0 +1,66 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.compiler.it</groupId>
+  <artifactId>fail-on-warning</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Werror warnings build</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.14</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <verbose>true</verbose>
+          <debug>true</debug>
+          <optimize>true</optimize>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <failOnWarning>true</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all,-options,-path</arg>
+          </compilerArgs>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-compiler-plugin/src/it/fail-on-warning/src/main/java/org/maven/test/Main.java
+++ b/maven-compiler-plugin/src/it/fail-on-warning/src/main/java/org/maven/test/Main.java
@@ -1,0 +1,35 @@
+package org.maven.test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+public class Main {
+    /**
+     * @param args
+     */
+    public static void main(String[] args) {
+        List blah = new ArrayList();
+        blah.add("hello");
+    }
+}

--- a/maven-compiler-plugin/src/it/fail-on-warning/verify.groovy
+++ b/maven-compiler-plugin/src/it/fail-on-warning/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def logFile = new File( basedir, 'build.log' )
+assert logFile.exists()
+content = logFile.text
+
+assert content.contains( 'Compilation failure' )
+assert !content.contains( 'invalid flag' )
+assert content.contains( 'unchecked call to add(E) as a member of the raw type ' ) // List or java.util.List

--- a/maven-compiler-plugin/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/maven-compiler-plugin/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -85,12 +85,12 @@ public abstract class AbstractCompilerMojo
 {
 
     static final String DEFAULT_SOURCE = "1.5";
-    
+
     static final String DEFAULT_TARGET = "1.5";
-    
+
     // Used to compare with older targets
     static final String MODULE_INFO_TARGET = "1.9";
-    
+
     // ----------------------------------------------------------------------
     // Configurables
     // ----------------------------------------------------------------------
@@ -102,14 +102,14 @@ public abstract class AbstractCompilerMojo
      */
     @Parameter( property = "maven.compiler.failOnError", defaultValue = "true" )
     private boolean failOnError = true;
-    
+
     /**
      * Indicates whether the build will continue even if there are compilation warnings.
      *
      * @since 3.6
      */
     @Parameter( property = "maven.compiler.failOnWarning", defaultValue = "false" )
-    private boolean failOnWarning;  
+    private boolean failOnWarning;
 
     /**
      * Set to <code>true</code> to include debugging information in the compiled class files.
@@ -162,12 +162,12 @@ public abstract class AbstractCompilerMojo
 
     /**
      * The -release argument for the Java compiler, supported since Java9
-     * 
+     *
      * @since 3.6
      */
     @Parameter( property = "maven.compiler.release" )
     protected String release;
-    
+
     /**
      * The -encoding argument for the Java compiler.
      *
@@ -372,7 +372,7 @@ public abstract class AbstractCompilerMojo
      * This overrules the toolchain selected by the maven-toolchain-plugin.
      * </p>
      * <strong>note:</strong> requires at least Maven 3.3.1
-     * 
+     *
      * @since 3.6
      */
     @Parameter
@@ -493,7 +493,7 @@ public abstract class AbstractCompilerMojo
     protected abstract List<String> getModulepathElements();
 
     protected abstract List<String> getCompileSourceRoots();
-    
+
     protected abstract void preparePaths( Set<File> sourceFiles );
 
     protected abstract File getOutputDirectory();
@@ -608,7 +608,7 @@ public abstract class AbstractCompilerMojo
         compilerConfiguration.setSourceVersion( getSource() );
 
         compilerConfiguration.setTargetVersion( getTarget() );
-        
+
         compilerConfiguration.setReleaseVersion( getRelease() );
 
         compilerConfiguration.setProc( proc );
@@ -689,6 +689,8 @@ public abstract class AbstractCompilerMojo
             }
         }
 
+        compilerConfiguration.setFailOnWarning( failOnWarning );
+
         compilerConfiguration.setExecutable( executable );
 
         compilerConfiguration.setWorkingDirectory( basedir );
@@ -747,7 +749,7 @@ public abstract class AbstractCompilerMojo
                 canUpdateTarget = compiler.canUpdateTarget( compilerConfiguration );
 
                 sources = getCompileSources( compiler, compilerConfiguration );
-                
+
                 preparePaths( sources );
 
                 incrementalBuildHelperRequest = new IncrementalBuildHelperRequest().inputFiles( sources );
@@ -802,7 +804,7 @@ public abstract class AbstractCompilerMojo
                 {
                     compilerConfiguration.setSourceFiles( staleSources );
                 }
-                
+
                 preparePaths( compilerConfiguration.getSourceFiles() );
             }
             catch ( CompilerException e )
@@ -817,12 +819,12 @@ public abstract class AbstractCompilerMojo
                 return;
             }
         }
-        
+
         // Dividing pathElements of classPath and modulePath is based on sourceFiles
         compilerConfiguration.setClasspathEntries( getClasspathElements() );
 
         compilerConfiguration.setModulepathEntries( getModulepathElements() );
-        
+
         Map<String, String> effectiveCompilerArguments = getCompilerArguments();
 
         String effectiveCompilerArgument = getCompilerArgument();
@@ -998,7 +1000,8 @@ public abstract class AbstractCompilerMojo
             }
         }
 
-        if ( failOnError && !compilerResult.isSuccess() )
+        if ( ( failOnError && !compilerResult.isSuccess() )
+             || ( failOnWarning && !warnings.isEmpty() ) )
         {
             for ( CompilerMessage message : others )
             {
@@ -1230,7 +1233,7 @@ public abstract class AbstractCompilerMojo
     private Toolchain getToolchain()
     {
         Toolchain tc = null;
-        
+
         if ( jdkToolchain != null )
         {
             // Maven 3.3.1 has plugin execution scoped Toolchain Support
@@ -1271,12 +1274,12 @@ public abstract class AbstractCompilerMojo
                 // ignore
             }
         }
-        
+
         if ( tc == null )
         {
             tc = toolchainManager.getToolchainFromBuildContext( "jdk", session );
         }
-        
+
         return tc;
     }
 
@@ -1408,7 +1411,7 @@ public abstract class AbstractCompilerMojo
         List<String> pathElements = new ArrayList<String>();
         pathElements.addAll( getClasspathElements() );
         pathElements.addAll( getModulepathElements() );
-        
+
         for ( String pathElement : pathElements )
         {
             // ProjectArtifacts are artifacts which are available in the local project

--- a/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
+++ b/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
@@ -293,6 +293,25 @@ public class CompilerMojoTestCase
         }
     }
 
+    public void testCompileFailOnWarning()
+            throws Exception
+    {
+        CompilerMojo compileMojo = getCompilerMojo( "target/test-classes/unit/compiler-failonwarning-test/plugin-config.xml" );
+
+        setVariableValueToObject( compileMojo, "compilerManager", new CompilerManagerStub( false, true ) );
+
+        try
+        {
+            compileMojo.execute();
+
+            fail( "Should throw an exception" );
+        }
+        catch ( CompilationFailureException e )
+        {
+            //expected
+        }
+    }
+
     public void testCompileFailOnError()
         throws Exception
     {

--- a/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerManagerStub.java
+++ b/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerManagerStub.java
@@ -30,19 +30,27 @@ public class CompilerManagerStub
 {
     private boolean shouldFail;
 
+    private boolean shouldWarn;
+
     public CompilerManagerStub()
     {
-        this( false );
+        this( false, false );
     }
 
     public CompilerManagerStub( boolean shouldFail )
     {
+        this (shouldFail, false );
+    }
+
+    public CompilerManagerStub ( boolean shouldFail, boolean shouldWarn )
+    {
         this.shouldFail = shouldFail;
+        this.shouldWarn = shouldWarn;
     }
 
     public org.codehaus.plexus.compiler.Compiler getCompiler( String compilerId )
         throws NoSuchCompilerException
     {
-        return new CompilerStub( shouldFail );
+        return new CompilerStub( shouldFail, shouldWarn );
     }
 }

--- a/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerStub.java
+++ b/maven-compiler-plugin/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerStub.java
@@ -39,14 +39,17 @@ public class CompilerStub
 {
     private boolean shouldFail;
 
+    private boolean shouldWarn;
+
     public CompilerStub()
     {
-        this( false );
+        this( false, false );
     }
 
-    public CompilerStub( boolean shouldFail )
+    public CompilerStub( boolean shouldFail, boolean shouldWarn )
     {
         this.shouldFail = shouldFail;
+        this.shouldWarn = shouldWarn;
     }
 
     public CompilerOutputStyle getCompilerOutputStyle()
@@ -120,9 +123,23 @@ public class CompilerStub
         {
             throw new CompilerException( "An exception occurred while creating output file", e );
         }
-        
-        return new CompilerResult( !shouldFail,
-            Collections.singletonList( new CompilerMessage( "message 1", CompilerMessage.Kind.OTHER ) ) );
+
+        List<CompilerMessage> compilerMessages;
+
+        if ( shouldFail )
+        {
+            compilerMessages = Collections.singletonList(new CompilerMessage( "message 1", CompilerMessage.Kind.ERROR ));
+        }
+        else  if ( shouldWarn )
+        {
+            compilerMessages = Collections.singletonList(new CompilerMessage( "message 1", CompilerMessage.Kind.WARNING ));
+        }
+        else
+        {
+            compilerMessages = Collections.singletonList(new CompilerMessage( "message 1", CompilerMessage.Kind.OTHER ));
+        }
+
+        return new CompilerResult( !shouldFail, compilerMessages );
     }
 
     public String[] createCommandLine( CompilerConfiguration compilerConfiguration )

--- a/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/plugin-config.xml
+++ b/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/plugin-config.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>true</failOnWarning>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/target/test-classes/unit/compiler-basic-test/src/main/java</compileSourceRoot>
+          </compileSourceRoots>
+          <compilerId>javac</compilerId>
+          <debug>true</debug>
+          <outputDirectory>${basedir}/target/test/unit/compiler-basic-test/target/classes</outputDirectory>
+          <buildDirectory>${basedir}/target/test/unit/compiler-basic-test/target</buildDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/src/main/java/TestCompile0.java
+++ b/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/src/main/java/TestCompile0.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestCompile0
+{
+
+    public TestCompile0()
+    {
+        List xxx = new ArrayList();
+        System.out.println( "Woo Hoo!" );
+    }
+
+}

--- a/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/src/test/java/TestCompile0Test.java
+++ b/maven-compiler-plugin/src/test/resources/unit/compiler-failonwarning-test/src/test/java/TestCompile0Test.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.TestCase;
+
+public class TestCompile0Test
+    extends TestCase
+{
+    public void testCompile0Test()
+    {
+        TestCompile0 test = new TestCompile0();
+    }
+}


### PR DESCRIPTION
Support for "failOnWarning" was added in the 3.6.0 release. This is mostly unit and integration testing for the flag that I still had lying around. Would be a shame to go to waste.
