### PR TITLE
[MJARSIGNER-53] - Add support of the "certchain" option in the "sign" mojo

### DIFF
--- a/maven-jarsigner-plugin/pom.xml
+++ b/maven-jarsigner-plugin/pom.xml
@@ -109,7 +109,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-jarsigner</artifactId>
-      <version>1.4</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
 
   </dependencies>

--- a/maven-jarsigner-plugin/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/maven-jarsigner-plugin/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -80,6 +80,19 @@ public class JarsignerSignMojo
      */
     @Parameter( property = "jarsigner.tsacert" )
     private String tsacert;
+    
+    /**
+     * Location of the extra certchain file.
+     * See 
+     * <a href="http://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">
+     *   Java SE 7 documentation
+     * </a>
+     * for more info.
+     * 
+     * @since TODO
+     */
+    @Parameter( property = "jarsigner.certchain", readonly = true, required = false )
+    private File certchain;
 
     @Override
     protected String getCommandlineInfo( final Commandline commandLine )
@@ -121,6 +134,7 @@ public class JarsignerSignMojo
         request.setSigfile( sigfile );
         request.setTsaLocation( tsa );
         request.setTsaAlias( tsacert );
+        request.setCertchain( certchain );
 
         // Special handling for passwords through the Maven Security Dispatcher
         request.setKeypass( decrypt( keypass ) );


### PR DESCRIPTION
This adds a new optional parameter for "certchain". If the maintainers are fine with the approach, I will add additional integration tests.

Upstream pull-request: https://github.com/apache/maven-shared/pull/24

[MJARSIGNER-53](https://issues.apache.org/jira/browse/MJARSIGNER-53)
