### PR TITLE
isolate and fix issue with PMD Report, includeXmlInSite - invalid xml file 

### DIFF
--- a/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReport.java
+++ b/maven-pmd-plugin/src/main/java/org/apache/maven/plugin/pmd/PmdReport.java
@@ -574,6 +574,7 @@ public class PmdReport
             r.start();
             r.renderFileReport( report );
             r.end();
+            writer.flush();
 
             if ( includeXmlInSite )
             {

--- a/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/PmdReportTest.java
+++ b/maven-pmd-plugin/src/test/java/org/apache/maven/plugin/pmd/PmdReportTest.java
@@ -345,6 +345,33 @@ public class PmdReportTest
     }
 
     /**
+     * verify the pmd.xml file is included in the site when requested. 
+     * @throws Exception
+     */
+    public void testIncludeXmlInSite()
+            throws Exception
+        {
+            File testPom = new File( getBasedir(), "src/test/resources/unit/default-configuration/pmd-report-include-xml-in-site-plugin-config.xml" );
+            PmdReport mojo = (PmdReport) lookupMojo( "pmd", testPom );
+            mojo.execute();
+
+            File generatedFile = new File( getBasedir(), "target/test/unit/default-configuration/target/site/pmd.html" );
+            assertTrue( FileUtils.fileExists( generatedFile.getAbsolutePath() ) );
+            // verify the pmd file is included in site
+            File generatedXmlFile = new File( getBasedir(), "target/test/unit/default-configuration/target/site/pmd.xml" );
+            assertTrue( FileUtils.fileExists( generatedXmlFile.getAbsolutePath() ) );
+
+            String pmdXmlTarget = readFile( new File( getBasedir(), "target/test/unit/default-configuration/target/pmd.xml" ) );
+            assertTrue( pmdXmlTarget.contains( "</pmd>" ) );
+
+            // check that pmd.xml file has the closing element
+            String pmdXml = readFile( new File( getBasedir(), "target/test/unit/default-configuration/target/site/pmd.xml" ) );
+            assertTrue( pmdXml.contains( "</pmd>" ) );
+
+            
+        }
+    
+    /**
      * Read the contents of the specified file object into a string
      *
      * @param file the file to be read
@@ -368,7 +395,7 @@ public class PmdReportTest
     }
 
     /**
-     * Verify the correct working of the localtionTemp method
+     * Verify the correct working of the locationTemp method
      *
      * @throws Exception
      */

--- a/maven-pmd-plugin/src/test/resources/unit/default-configuration/pmd-report-include-xml-in-site-plugin-config.xml
+++ b/maven-pmd-plugin/src/test/resources/unit/default-configuration/pmd-report-include-xml-in-site-plugin-config.xml
@@ -1,0 +1,62 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>def.configuration</groupId>
+  <artifactId>default-configuration</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <inceptionYear>2006</inceptionYear>
+  <name>Maven PMD Plugin Default Configuration Test</name>
+  <url>http://maven.apache.org</url>
+  <build>
+    <finalName>default-configuration</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugin.pmd.stubs.DefaultConfigurationMavenProjectStub"/>
+          <outputDirectory>${basedir}/target/test/unit/default-configuration/target/site</outputDirectory>
+          <targetDirectory>${basedir}/target/test/unit/default-configuration/target</targetDirectory>
+          <format>xml</format>
+          <sourceEncoding>UTF-8</sourceEncoding>
+          <includeXmlInSite>true</includeXmlInSite>
+          
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>pmd</groupId>
+            <artifactId>pmd</artifactId>
+            <version>3.6</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>


### PR DESCRIPTION
for PMD reports with format XML and includeXmlInSite=true, the pmd.xml file copied to the site directory does not have the closing pmd element.

I've attached a failing test case, along with the small code change, required to fix this. 