### PR TITLE
MJDEPS-9 Introduce named property for failOnWarning

### DIFF
--- a/maven-jdeps-plugin/src/main/java/org/apache/maven/plugin/jdeps/AbstractJDepsMojo.java
+++ b/maven-jdeps-plugin/src/main/java/org/apache/maven/plugin/jdeps/AbstractJDepsMojo.java
@@ -77,7 +77,7 @@ public abstract class AbstractJDepsMojo
     /**
      * Indicates whether the build will continue even if there are jdeps warnings.
      */
-    @Parameter( defaultValue = "true" )
+    @Parameter( defaultValue = "true", property = "jdeps.failOnWarning" )
     private boolean failOnWarning;
     
     /**


### PR DESCRIPTION
Introduce `jdeps.failOnWarning` named property to support command line and `<properties>` declarations.

https://issues.apache.org/jira/browse/MJDEPS-9