### PR TITLE
MPH-124: add alias to describe detail

### DIFF
--- a/maven-help-plugin/src/main/java/org/apache/maven/plugins/help/DescribeMojo.java
+++ b/maven-help-plugin/src/main/java/org/apache/maven/plugins/help/DescribeMojo.java
@@ -682,6 +682,12 @@ public class DescribeMojo
             }
             append( buffer, parameter.getName() + defaultVal, 2 );
 
+            String alias = parameter.getAlias();
+            if ( !StringUtils.isEmpty( alias ) )
+            {
+                append ( buffer, "Alias", alias, 3 );
+            }
+
             if ( parameter.isRequired() )
             {
                 append( buffer, "Required", "true", 3 );


### PR DESCRIPTION
Simply add the alias to the detail output, if it exists.

Sample output from one of our custom plugins:
```
[INFO] 'helios-dev:deploy-apollo' is a plugin goal (aka mojo).
Mojo: 'helios-dev:deploy-apollo'
helios-dev:deploy-apollo
  Description: (no description available)
  Implementation: ca.nanometrics.maven.helios.development.DeployApolloMojo
  Language: java

  Available parameters:

    m_bboverlay (Default:
    ${project.build.directory}/bboverlay-tmp/${project.artifactId})
      Alias: bboverlay
      Required: true
      User property: bboverlay-tmp
      (no description available)

    m_host
      Alias: host
      Required: true
      User property: sshhost
      (no description available)

    m_keyFile (Default: ${user.home}/.ssh/id_rsa.helios)
      Alias: keyfile
      User property: keyfile
      (no description available)
```