### PR TITLE
[MDEP-584] Update plexus-utils to 3.1.0

### DIFF
--- a/maven-dependency-plugin/pom.xml
+++ b/maven-dependency-plugin/pom.xml
@@ -178,7 +178,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.24</version>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestCopyMojo.java
+++ b/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestCopyMojo.java
@@ -666,12 +666,20 @@ public class TestCopyMojo
         assertEquals( time, copiedFile.lastModified() );
     }
 
+    /**
+     * Test that the given release artifact is copied, and the copy is overwritten if the Mojo is executed again.
+     *
+     * @throws Exception On errors
+     */
+
     public void testCopyOverWriteReleases()
         throws Exception
     {
         stubFactory.setCreateFiles( true );
         Artifact release = stubFactory.getReleaseArtifact();
-        assertTrue( release.getFile().setLastModified( System.currentTimeMillis() - 2000 ) );
+
+        assertTrue( release.getFile().setLastModified( 1000L ) );
+        assertEquals( 1000L, release.getFile().lastModified() );
 
         ArtifactItem item = new ArtifactItem( release );
 
@@ -685,21 +693,29 @@ public class TestCopyMojo
 
         File copiedFile = new File( item.getOutputDirectory(), item.getDestFileName() );
 
-        // round up to the next second
-        long time = System.currentTimeMillis() - 2000;
-        assertTrue( copiedFile.setLastModified( time ) );
+        assertTrue( copiedFile.setLastModified( 2000L ) );
+        assertEquals( 2000L, copiedFile.lastModified() );
 
         mojo.execute();
 
-        assertTrue( time < copiedFile.lastModified() );
+        long timeCopyNow = copiedFile.lastModified();
+        assertEquals( 1000L, timeCopyNow );
     }
+
+    /**
+     * Test that the given snapshot artifact is copied, and the copy is overwritten if the Mojo is executed again.
+     *
+     * @throws Exception On errors
+     */
 
     public void testCopyOverWriteSnapshot()
         throws Exception
     {
         stubFactory.setCreateFiles( true );
         Artifact artifact = stubFactory.getSnapshotArtifact();
-        assertTrue( artifact.getFile().setLastModified( System.currentTimeMillis() - 2000 ) );
+
+        assertTrue( artifact.getFile().setLastModified( 1000L ) );
+        assertEquals( 1000L, artifact.getFile().lastModified() );
 
         ArtifactItem item = new ArtifactItem( artifact );
 
@@ -714,13 +730,13 @@ public class TestCopyMojo
 
         File copiedFile = new File( item.getOutputDirectory(), item.getDestFileName() );
 
-        // round up to the next second
-        long time = System.currentTimeMillis() - 2000;
-        assertTrue( copiedFile.setLastModified( time ) );
+        assertTrue( copiedFile.setLastModified( 2000L ) );
+        assertEquals( 2000L, copiedFile.lastModified() );
 
         mojo.execute();
 
-        assertTrue( time < copiedFile.lastModified() );
+        long timeCopyNow = copiedFile.lastModified();
+        assertEquals( 1000L, timeCopyNow );
     }
 
     public void testCopyOverWriteIfNewer()

--- a/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
+++ b/maven-dependency-plugin/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
@@ -551,13 +551,21 @@ public class TestCopyDependenciesMojo
         assertEquals( time, copiedFile.lastModified() );
     }
 
+    /**
+     * Test that the given artifact is copied, and the copy is overwritten if the Mojo is executed again.
+     *
+     * @throws Exception On errors
+     */
+
     public void testOverWriteRelease()
-        throws MojoExecutionException, InterruptedException, IOException, MojoFailureException
+        throws Exception
     {
 
         Set<Artifact> artifacts = new HashSet<Artifact>();
         Artifact release = stubFactory.getReleaseArtifact();
-        assertTrue( release.getFile().setLastModified( System.currentTimeMillis() - 2000 ) );
+
+        assertTrue( release.getFile().setLastModified( 1000L ) );
+        assertEquals( 1000L, release.getFile().lastModified() );
 
         artifacts.add( release );
 
@@ -571,19 +579,13 @@ public class TestCopyDependenciesMojo
 
         File copiedFile = new File( mojo.outputDirectory, DependencyUtil.getFormattedFileName( release, false ) );
 
-        Thread.sleep( 100 );
-        // round down to the last second
-        long time = System.currentTimeMillis();
-        time = time - ( time % 1000 );
-        assertTrue( copiedFile.setLastModified( time ) );
-        // wait at least a second for filesystems that only record to the
-        // nearest second.
-        Thread.sleep( 1000 );
+        assertTrue( copiedFile.setLastModified( 2000L ) );
+        assertEquals( 2000L, copiedFile.lastModified() );
 
         mojo.execute();
 
-        assertTrue( "time = " + time + " should be < to " + copiedFile.lastModified(),
-                    time < copiedFile.lastModified() );
+        long timeCopyNow = copiedFile.lastModified();
+        assertEquals( 1000L, timeCopyNow );
     }
 
     public void testDontOverWriteSnap()
@@ -619,13 +621,21 @@ public class TestCopyDependenciesMojo
         assertEquals( time, copiedFile.lastModified() );
     }
 
+    /**
+     * Test that the given artifact is copied, and the copy is overwritten if the Mojo is executed again.
+     *
+     * @throws Exception On errors
+     */
+
     public void testOverWriteSnap()
-        throws MojoExecutionException, InterruptedException, IOException, MojoFailureException
+        throws Exception
     {
 
         Set<Artifact> artifacts = new HashSet<Artifact>();
         Artifact snap = stubFactory.getSnapshotArtifact();
-        assertTrue( snap.getFile().setLastModified( System.currentTimeMillis() - 2000 ) );
+
+        assertTrue( snap.getFile().setLastModified( 1000L ) );
+        assertEquals( 1000L, snap.getFile().lastModified() );
 
         artifacts.add( snap );
 
@@ -640,18 +650,13 @@ public class TestCopyDependenciesMojo
 
         File copiedFile = new File( mojo.outputDirectory, DependencyUtil.getFormattedFileName( snap, false ) );
 
-        Thread.sleep( 100 );
-        // round down to the last second
-        long time = System.currentTimeMillis();
-        time = time - ( time % 1000 );
-        assertTrue( copiedFile.setLastModified( time ) );
-        // wait at least a second for filesystems that only record to the
-        // nearest second.
-        Thread.sleep( 1000 );
+        assertTrue( copiedFile.setLastModified( 2000L ) );
+        assertEquals( 2000L, copiedFile.lastModified() );
 
         mojo.execute();
 
-        assertTrue( time < copiedFile.lastModified() );
+        long timeCopyNow = copiedFile.lastModified();
+        assertEquals( 1000L, timeCopyNow );
     }
 
     public void testGetDependencies()


### PR DESCRIPTION
This updates the plexus-utils dependency to 3.1.0. It corrects four
unit tests that were failing due to new behaviour in 3.1.0: It appears
that the new plexus-utils copies the lastModified attributes of files,
and the old tests were implicitly depending on the attributes not
being copied.

Fixes: MDEP-584