### PR TITLE
[MJAVADOC-489] Find the main module descriptor

### DIFF
--- a/maven-javadoc-plugin/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/maven-javadoc-plugin/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4653,9 +4653,11 @@ public abstract class AbstractJavadocMojo
             addArgIf( arguments, breakiterator, "-breakiterator", SINCE_JAVADOC_1_5 );
         }
 
-        File mainDescriptor = new File( "src/main/java/module-info.java" );
-        
-        if ( mainDescriptor.exists() && !isTest() )
+        List<String> roots = getProjectSourceRoots( getProject() );
+
+        File mainDescriptor = findMainDescriptor( roots );
+
+        if ( mainDescriptor != null && !isTest() )
         {
             LocationManager locationManager = new LocationManager();
             ResolvePathsRequest<File> request =
@@ -4737,6 +4739,19 @@ public abstract class AbstractJavadocMojo
                 arguments.add( option );
             }
         }
+    }
+
+    private static File findMainDescriptor( List<String> roots )
+    {
+        for ( String root : roots )
+        {
+            File descriptorFile = new File( root, "module-info.java" ).getAbsoluteFile();
+            if ( descriptorFile.exists() )
+            {
+                return descriptorFile;
+            }
+        }
+        return null;
     }
 
     /**

--- a/maven-javadoc-plugin/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/maven-javadoc-plugin/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4742,12 +4742,17 @@ public abstract class AbstractJavadocMojo
     }
 
     private static File findMainDescriptor( List<String> roots )
+        throws MavenReportException
     {
         for ( String root : roots )
         {
             File descriptorFile = new File( root, "module-info.java" ).getAbsoluteFile();
             if ( descriptorFile.exists() )
             {
+                if ( !descriptorFile.isFile() )
+                {
+                    throw new MavenReportException( descriptorFile + " is not a regular file" );
+                }
                 return descriptorFile;
             }
         }


### PR DESCRIPTION
The existing code was checking for the existence of a file
"src/main/module-info.java" relative to the current directory. The
problem is that in a multi-module build, the current directory is
the project root, not the root of the current module. As a result,
the module descriptor was not being found and all dependencies were
ending up on the classpath instead.

Fixes: MJAVADOC-489