### PR TITLE
Fixed the example code in usage.apt.vm

### DIFF
--- a/maven-checkstyle-plugin/src/site/apt/usage.apt.vm
+++ b/maven-checkstyle-plugin/src/site/apt/usage.apt.vm
@@ -93,17 +93,17 @@ mvn checkstyle:checkstyle
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-checkstyle-plugin</artifactId>
    <version>${project.version}</version>
+   <configuration>
+     <configLocation>checkstyle.xml</configLocation>
+     <encoding>UTF-8</encoding>
+     <consoleOutput>true</consoleOutput>
+     <failsOnError>true</failsOnError>
+     <linkXRef>false</linkXRef>
+   </configuration>
    <executions>
      <execution>
        <id>validate</id>
        <phase>validate</phase>
-       <configuration>
-         <configLocation>checkstyle.xml</configLocation>
-         <encoding>UTF-8</encoding>
-         <consoleOutput>true</consoleOutput>
-         <failsOnError>true</failsOnError>
-         <linkXRef>false</linkXRef>
-       </configuration>
        <goals>
          <goal>check</goal>
        </goals>


### PR DESCRIPTION
Had the original code copied to my project and it was resulting in an error. After the configuration tag directly under the plugin tag everything worked.

Here is the related StackOverflow question with the solution: https://stackoverflow.com/questions/49606513/maven-checkstyle-plugin3-0-0check-failed-during-checkstyle-configuration-can/49610945#49610945